### PR TITLE
CR289 Use latest api to get the uprn being serialiased as a string.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.44</version>
+      <version>0.0.46</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Motivation and Context
This change uses the latest api project which has the correct serialisation of the uprn field. This is now output as a string:

```
$ curl -s -H "Content-Type: application/json" --user $CC_USERNAME:$CC_PASSWORD "$CC/cases/9347a654-4f13-11e9-8647-d663bd873d93?case-events=true" | jq | head -15
{
  "id": "9347a654-4f13-11e9-8647-d663bd873d93",
  "caseRef": "123123",
  "caseType": "HH",
  "createdDateTime": "2019-04-14T13:45:26.564+01:00",
  "addressLine1": "Napier House",
  "addressLine2": "11 Park Street",
  "addressLine3": "Parkhead",
  "townName": "Glasgow",
  "region": "E",
  "postcode": "G1 2AA",
  "uprn": "1347459999",
  "caseEvents": null
}
```