### PR TITLE
Cr314 report not found errors as 404

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,4 +42,3 @@ Is switched off by default for clean deploy. Switch on with;
     
 ## Copyright
 Copyright (C) 2019 Crown Copyright (Office for National Statistics)
-

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.31</version>
+      <version>0.0.32</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Motivation and Context
This CR fixes the bug reported by Serco. 
404 errors were being reported in the body of a http response but the status code for the http request itself would be 500 instead of 404.

For details on the bug report see: https://collaborate2.ons.gov.uk/jira/browse/CR-314

The rest of this pull request reuses the pull request text for the actual fix to the RestClient:

# What has changed
This pull request covers 3 fixes:
1) No top level exception catching for the exceptions thrown during rest calls. So the, say, 404 status got mapped to a generic 500.
2) RestClient method for getResources (not getResource method) had error handling that didn't match a real server. The getResources() is now delegating to getResource().
3) Test failure due to the getResource handling of 204 errors. Now throwing exception for null content, just as per original RestClient code.

# How to test?
Run unit tests and manually hit the endpoints of the Contact Centre.
I've tested this against the fake case service and have been able to use this to simulate 404 errors in the case service and confirm that they are reported with the correct status code in the http response.
