### PR TITLE
CR314 Using latest common for cleaned up error reporting

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.32</version>
+      <version>0.0.33</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Motivation and Context
Use latest common service for...

Minor improvements to fix:
- More logging done at warning level instead of error level.
- Improved text visible to external caller on 404 error. 