### PR TITLE
CR-416 Commented out code which sets the personal details for a refusal

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -356,10 +356,12 @@ public class CaseServiceImpl implements CaseService {
 
     // Populate contact
     Contact contact = new Contact();
-    contact.setTitle(refusalRequest.getTitle());
-    contact.setForename(refusalRequest.getForename());
-    contact.setSurname(refusalRequest.getSurname());
-    contact.setTelNo(refusalRequest.getTelNo());
+    // --- Start of code commented out for 2019 rehearsal. CR-416. ---
+    // contact.setTitle(refusalRequest.getTitle());
+    // contact.setForename(refusalRequest.getForename());
+    // contact.setSurname(refusalRequest.getSurname());
+    // contact.setTelNo(refusalRequest.getTelNo());
+    // --- End of code commented out for 2019 rehearsal. CR-416. ---
     refusal.setContact(contact);
 
     // Populate address

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -405,12 +405,14 @@ public class CaseServiceImplTest {
     assertNull(refusal.getAgentId());
     assertEquals(expectedEventCaseId, refusal.getCollectionCase().getId());
     // Validate contact details
-    Contact actualContact = refusal.getContact();
-    assertEquals("Mr", actualContact.getTitle());
-    assertEquals("Steve", actualContact.getForename());
-    assertEquals("Jones", actualContact.getSurname());
-    assertNull(actualContact.getEmail());
-    assertEquals("+447890000000", actualContact.getTelNo());
+    // --- Start of code commented out for 2019 rehearsal. CR-416. ---
+    // Contact actualContact = refusal.getContact();
+    // assertEquals("Mr", actualContact.getTitle());
+    // assertEquals("Steve", actualContact.getForename());
+    // assertEquals("Jones", actualContact.getSurname());
+    // assertNull(actualContact.getEmail());
+    // assertEquals("+447890000000", actualContact.getTelNo());
+    // --- End of code commented out for 2019 rehearsal. CR-416. ---
     // Validate address
     AddressCompact address = refusal.getAddress();
     assertEquals("1 High Street", address.getAddressLine1());


### PR DESCRIPTION
# Motivation and Context
This removes personal contact details (name, phone number, etc) for a refusal.
This is a temporary change for the 2019 rehearsal.

# What has changed
I've commented out the code which was setting the personal contact details. Similar change also done in the unit test. The start and end of the commented out code has been marked, and to aid future tracking includes 'CR-416'. 

# How to test?
Run the unit tests. I have also manually tested this service. and examined the event published to rabbit. 

# Links
See: https://collaborate2.ons.gov.uk/jira/browse/CR-416