### PR TITLE
Cr 644 search address index by uprn

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
@@ -47,7 +47,7 @@ public class AddressServiceClientServiceImpl {
             path, AddressIndexSearchResultsDTO.class, null, queryParams, new Object[] {});
     log.with("status", addressIndexResponse.getStatus().getCode())
         .with("addresses", addressIndexResponse.getResponse().getAddresses().size())
-        .debug("AddressQuery response received");
+        .debug("Address query response received");
 
     return addressIndexResponse;
   }
@@ -72,7 +72,22 @@ public class AddressServiceClientServiceImpl {
             path, AddressIndexSearchResultsDTO.class, null, queryParams, postcode);
     log.with("status", addressIndexResponse.getStatus().getCode())
         .with("addresses", addressIndexResponse.getResponse().getAddresses().size())
-        .debug("PostcodeQuery response received");
+        .debug("Postcode query response received");
+
+    return addressIndexResponse;
+  }
+
+  public AddressIndexSearchResultsDTO searchByUPRN(Long uprn) {
+    log.debug("Delegating UPRN search to AddressIndex service");
+
+    // Ask Address Index to do uprn search
+    String path = appConfig.getAddressIndexSettings().getUprnLookupPath();
+
+    AddressIndexSearchResultsDTO addressIndexResponse =
+        addressIndexClient.getResource(path, AddressIndexSearchResultsDTO.class, uprn.toString());
+    log.with("status", addressIndexResponse.getStatus().getCode())
+        .with("addresses", addressIndexResponse.getResponse().getAddresses().size())
+        .debug("UPRN query response received");
 
     return addressIndexResponse;
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/model/AddressIndexResponseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/model/AddressIndexResponseDTO.java
@@ -8,7 +8,7 @@ import lombok.Data;
 
 @Data
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class PostcodeSearchResponseDTO {
+public class AddressIndexResponseDTO {
 
   private String postcode;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/model/AddressIndexSearchResultsDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/model/AddressIndexSearchResultsDTO.java
@@ -10,7 +10,7 @@ public class AddressIndexSearchResultsDTO {
 
   private String dataVersion;
 
-  private PostcodeSearchResponseDTO response;
+  private AddressIndexResponseDTO response;
 
   private ResponseStatusData status;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/model/PostcodeSearchResponseDTO.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/model/PostcodeSearchResponseDTO.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.client.addressindex.model;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import java.util.ArrayList;
 import lombok.Data;
@@ -10,6 +12,8 @@ public class PostcodeSearchResponseDTO {
 
   private String postcode;
 
+  @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+  @JsonAlias({"address"})
   private ArrayList<AddressIndexAddressDTO> addresses;
 
   private int limit;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AddressIndexSettings.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AddressIndexSettings.java
@@ -7,5 +7,6 @@ import uk.gov.ons.ctp.common.rest.RestClientConfig;
 public class AddressIndexSettings {
   private String addressQueryPath;
   private String postcodeLookupPath;
+  private String uprnLookupPath;
   private RestClientConfig restClientConfig;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/AddressService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/AddressService.java
@@ -7,12 +7,34 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.AddressUpdateR
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.PostcodeQueryRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.ResponseDTO;
 
+/** Service responsible for dealing with address related functionality */
 public interface AddressService {
 
+  /**
+   * Search for an address by search string
+   *
+   * @param addressQueryRequest with search string, offset and limit for pagination
+   * @return result object containing list of addresses
+   */
   public AddressQueryResponseDTO addressQuery(AddressQueryRequestDTO addressQueryRequest);
 
+  /**
+   * Search for an address by postcode
+   *
+   * @param postcodeQueryRequest with postcode, offset and limit for pagination
+   * @return result object containing list of addresses
+   */
   public AddressQueryResponseDTO postcodeQuery(PostcodeQueryRequestDTO postcodeQueryRequest);
 
+  /**
+   * Search for an address by uprn
+   *
+   * @param uprn Unique Property Reference No.
+   * @return result object as for other searches but with only ever 0 or 1 result
+   */
+  public AddressQueryResponseDTO uprnQuery(Long uprn);
+
+  // TODO
   public default ResponseDTO addressChange(AddressUpdateRequestDTO addressUpdateRequestDTO) {
     ResponseDTO fakeResponse = new ResponseDTO();
     fakeResponse.setId("8437625585067");

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/AddressServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/AddressServiceImpl.java
@@ -61,6 +61,22 @@ public class AddressServiceImpl implements AddressService {
     return results;
   }
 
+  @Override
+  public AddressQueryResponseDTO uprnQuery(Long uprn) {
+    log.with("uprnQueryRequest", uprn).debug("Running search by uprn");
+
+    // Delegate the query to Address Index
+    AddressIndexSearchResultsDTO addressIndexResponse = addressServiceClient.searchByUPRN(uprn);
+
+    // Summarise the returned addresses
+    AddressQueryResponseDTO results =
+        convertAddressIndexResultsToSummarisedAdresses(addressIndexResponse);
+
+    log.with("addresses", results.getAddresses().size())
+        .debug("Postcode search is returning addresses");
+    return results;
+  }
+
   private AddressQueryResponseDTO convertAddressIndexResultsToSummarisedAdresses(
       AddressIndexSearchResultsDTO addressIndexResponse) {
     ArrayList<AddressDTO> summarisedAddresses = new ArrayList<>();
@@ -86,7 +102,16 @@ public class AddressServiceImpl implements AddressService {
     AddressQueryResponseDTO queryResponse = new AddressQueryResponseDTO();
     queryResponse.setDataVersion(addressIndexResponse.getDataVersion());
     queryResponse.setAddresses(summarisedAddresses);
-    queryResponse.setTotal(addressIndexResponse.getResponse().getTotal());
+
+    int total = addressIndexResponse.getResponse().getTotal();
+    int arraySize = summarisedAddresses.size();
+
+    // UPRN search has no JSON total attribute as only one or zero
+    if (total > 0) {
+      queryResponse.setTotal(total);
+    } else {
+      queryResponse.setTotal(arraySize);
+    }
 
     return queryResponse;
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -101,6 +101,7 @@ spring:
 address-index-settings:
   address-query-path: /addresses
   postcode-lookup-path: /addresses/postcode/{postcode}
+  uprn-lookup-path: /addresses/uprn/{uprn}
   rest-client-config:
     scheme: http
     host: addressindex-api-beta.apps.devtest.onsclofo.uk

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.java
@@ -23,6 +23,12 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.AddressQueryRe
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.PostcodeQueryRequestDTO;
 
 public class AddressServiceClientServiceImplTest {
+
+  private static final String ADDRESS_QUERY_PATH = "/addresses";
+  private static final String POSTCODE_QUERY_PATH = "/addresses/postcode";
+  private static final String UPRN_QUERY_PATH = "/addresses/uprn/{uprn}";
+  private static final long UPRN = 100041045018L;
+
   @Mock AppConfig appConfig = new AppConfig();
 
   @Mock RestClient restClient;
@@ -40,8 +46,9 @@ public class AddressServiceClientServiceImplTest {
 
     // Mock the address index settings
     AddressIndexSettings addressIndexSettings = new AddressIndexSettings();
-    addressIndexSettings.setAddressQueryPath("/addresses");
-    addressIndexSettings.setPostcodeLookupPath("/addresses/postcode");
+    addressIndexSettings.setAddressQueryPath(ADDRESS_QUERY_PATH);
+    addressIndexSettings.setPostcodeLookupPath(POSTCODE_QUERY_PATH);
+    addressIndexSettings.setUprnLookupPath(UPRN_QUERY_PATH);
     Mockito.when(appConfig.getAddressIndexSettings()).thenReturn(addressIndexSettings);
   }
 
@@ -52,7 +59,11 @@ public class AddressServiceClientServiceImplTest {
         FixtureHelper.loadClassFixtures(AddressIndexSearchResultsDTO[].class).get(0);
     Mockito.when(
             restClient.getResource(
-                eq("/addresses"), eq(AddressIndexSearchResultsDTO.class), any(), any(), any()))
+                eq(ADDRESS_QUERY_PATH),
+                eq(AddressIndexSearchResultsDTO.class),
+                any(),
+                any(),
+                any()))
         .thenReturn(resultsFromAddressIndex);
 
     // Run the request and sanity check the results. We can't thoroughly check the data as it
@@ -78,7 +89,7 @@ public class AddressServiceClientServiceImplTest {
         FixtureHelper.loadClassFixtures(AddressIndexSearchResultsDTO[].class).get(0);
     Mockito.when(
             restClient.getResource(
-                eq("/addresses/postcode"),
+                eq(POSTCODE_QUERY_PATH),
                 eq(AddressIndexSearchResultsDTO.class),
                 any(),
                 any(),
@@ -97,5 +108,23 @@ public class AddressServiceClientServiceImplTest {
     assertEquals("[0]", queryParams.get("offset").toString());
     assertEquals("[100]", queryParams.get("limit").toString());
     assertEquals(2, queryParams.keySet().size());
+  }
+
+  @Test
+  public void testUPRNQueryProcessing() throws Exception {
+    // Build results to be returned from search
+    AddressIndexSearchResultsDTO resultsFromAddressIndex =
+        FixtureHelper.loadMethodFixtures(AddressIndexSearchResultsDTO[].class, null).get(0);
+    Mockito.when(
+            restClient.getResource(
+                eq(UPRN_QUERY_PATH),
+                eq(AddressIndexSearchResultsDTO.class),
+                eq(Long.toString(UPRN))))
+        .thenReturn(resultsFromAddressIndex);
+
+    AddressIndexSearchResultsDTO results = addressClientService.searchByUPRN(UPRN);
+    assertEquals("39", results.getDataVersion());
+    assertEquals(1, results.getResponse().getAddresses().size());
+    assertEquals(Long.toString(UPRN), results.getResponse().getAddresses().get(0).getUprn());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/AddressServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/AddressServiceImplTest.java
@@ -59,6 +59,25 @@ public class AddressServiceImplTest {
     verifyAddresses(results);
   }
 
+  @Test
+  public void testUPRNQueryProcessing() throws Exception {
+    // Build results to be returned from search
+    AddressIndexSearchResultsDTO addressIndexResults =
+        FixtureHelper.loadMethodFixtures(AddressIndexSearchResultsDTO[].class, null).get(0);
+    Mockito.when(addressClientService.searchByUPRN(any())).thenReturn(addressIndexResults);
+
+    // Run the request and verify results
+    AddressQueryResponseDTO results = addressService.uprnQuery(100041045018L);
+
+    assertEquals("39", results.getDataVersion());
+    assertEquals(1, results.getTotal());
+    ArrayList<AddressDTO> addresses = results.getAddresses();
+    assertEquals(1, addresses.size());
+    assertThat(addresses.get(0).getFormattedAddress(), startsWith("Unit 11p,"));
+    assertThat(addresses.get(0).getWelshFormattedAddress(), startsWith("Unit 11wp,"));
+    assertEquals("100041045018", addresses.get(0).getUprn());
+  }
+
   /**
    * Postcode and address queries return the same results, so this method validates the data in both
    * cases.

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.testUPRNQueryProcessing.AddressIndexSearchResultsDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.testUPRNQueryProcessing.AddressIndexSearchResultsDTO.json
@@ -1,0 +1,35 @@
+{
+  "apiVersion": "v_c875fa34fdfa1cf308505b8b6524dbe5e4824595",
+  "dataVersion": "39",
+  "errors": [],
+  "response": {
+    "address":
+      {
+        "uprn": "100041045018",
+        "parentUprn": "0",
+        "formattedAddress": "Unit 11f, Michael Browning Way, Exeter, EX2 8DD",
+        "formattedAddressNag": "Unit 11n, Michael Browning Way, Exeter, EX2 8DD",
+        "formattedAddressPaf": "Unit 11p, City Industrial Estate, Michael Browning Way, Exeter, EX2 8DD",
+        "welshFormattedAddressNag": "Unit 11wn, Michael Browning Way, Exeter, EX2 8DD",
+        "welshFormattedAddressPaf": "Unit 11wp, City Industrial Estate, Michael Browning Way, Exeter, EX2 8DD",
+        "fromSource": "EW",
+        "geo": {
+          "latitude": 50.714314,
+          "longitude": -3.5294223,
+          "easting": 292120,
+          "northing": 91637
+        },
+        "classificationCode": "CI03",
+        "lpiLogicalStatus": "1",
+        "confidenceScore": "1",
+        "underlyingScore": "1"
+      },
+    "historical": true,
+    "epoch": "",
+    "verbose": false
+  },
+  "status": {
+    "code": 200,
+    "message": "Ok"
+  }
+}

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/AddressServiceImplTest.testUPRNQueryProcessing.AddressIndexSearchResultsDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/AddressServiceImplTest.testUPRNQueryProcessing.AddressIndexSearchResultsDTO.json
@@ -1,0 +1,35 @@
+{
+  "apiVersion": "v_c875fa34fdfa1cf308505b8b6524dbe5e4824595",
+  "dataVersion": "39",
+  "errors": [],
+  "response": {
+    "address":
+      {
+        "uprn": "100041045018",
+        "parentUprn": "0",
+        "formattedAddress": "Unit 11f, Michael Browning Way, Exeter, EX2 8DD",
+        "formattedAddressNag": "Unit 11n, Michael Browning Way, Exeter, EX2 8DD",
+        "formattedAddressPaf": "Unit 11p, City Industrial Estate, Michael Browning Way, Exeter, EX2 8DD",
+        "welshFormattedAddressNag": "Unit 11wn, Michael Browning Way, Exeter, EX2 8DD",
+        "welshFormattedAddressPaf": "Unit 11wp, City Industrial Estate, Michael Browning Way, Exeter, EX2 8DD",
+        "fromSource": "EW",
+        "geo": {
+          "latitude": 50.714314,
+          "longitude": -3.5294223,
+          "easting": 292120,
+          "northing": 91637
+        },
+        "classificationCode": "CI03",
+        "lpiLogicalStatus": "1",
+        "confidenceScore": "1",
+        "underlyingScore": "1"
+      },
+    "historical": true,
+    "epoch": "",
+    "verbose": false
+  },
+  "status": {
+    "code": 200,
+    "message": "Ok"
+  }
+}


### PR DESCRIPTION
# Motivation and Context
Add the ability to search the remote Address Index (AI) service by UPRN. This is added to the service layer but not exposed directly through an endpoint, being utilised in later business flows.

# What has changed
Addition of uprnQuery to AddressService interface. The JSON response from AI for postcode and address string searches are the same. The JSON response for a UPRN search is very similar, but where only one, or no address can be returned for a UPRN the "addresses" array is renamed "address" and becomes a JSON object rather than array. The "offset", "limit" and "total" attributes are also removed from the JSON as no longer relevant. Rather than introduce another set of response objects for these minor differences and the extra code entailed I took the design decision to accommodate them simply in the AddressIndexResponseDTO class using this still as a common response object for all AI searches, with common processing. I believe this reduces the amount and complexity of the code. 

# How to test?
Additional Unit tests added as required to check new functionality. Running the Contact Centre locally may be tested in Postman by issuing appropriate URL e.g. http://localhost:8171/addresses/uprn/10013043967

