### PR TITLE
Cr 755 pass form type to eq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -155,7 +155,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>eq-launcher</artifactId>
-      <version>0.0.23-SNAPSHOT</version>
+      <version>0.0.23</version>
     </dependency>
 
     <!-- ONS END -->

--- a/pom.xml
+++ b/pom.xml
@@ -149,13 +149,13 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-case-api-client</artifactId>
-      <version>0.0.7</version>
+      <version>0.0.8</version>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>eq-launcher</artifactId>
-      <version>0.0.22</version>
+      <version>0.0.23-SNAPSHOT</version>
     </dependency>
 
     <!-- ONS END -->

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -274,7 +274,10 @@ public class CaseServiceImpl implements CaseService {
     SingleUseQuestionnaireIdDTO newQuestionnaireIdDto =
         caseServiceClient.getSingleUseQuestionnaireId(caseId, individual, individualCaseId);
     String questionnaireId = newQuestionnaireIdDto.getQuestionnaireId();
-    log.with("newQuestionnaireID", questionnaireId).info("Have generated new questionnaireId");
+    String formType = newQuestionnaireIdDto.getFormType();
+    log.with("newQuestionnaireID", questionnaireId)
+        .with("formType", formType)
+        .info("Have generated new questionnaireId");
 
     // Finally, build the url needed to launch the survey
     String encryptedPayload = "";
@@ -287,6 +290,7 @@ public class CaseServiceImpl implements CaseService {
               caseDetails,
               requestParamsDTO.getAgentId(),
               questionnaireId,
+              formType,
               null,
               null,
               appConfig.getKeystore());

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -414,8 +414,10 @@ public class CaseServiceImplTest {
 
     // Fake RM response for creating questionnaire ID
     String questionnaireId = "566786126";
+    String formType = "H";
     SingleUseQuestionnaireIdDTO newQuestionnaireIdDto = new SingleUseQuestionnaireIdDTO();
     newQuestionnaireIdDto.setQuestionnaireId(questionnaireId);
+    newQuestionnaireIdDto.setFormType(formType);
     Mockito.when(caseServiceClient.getSingleUseQuestionnaireId(eq(uuid), eq(individual), any()))
         .thenReturn(newQuestionnaireIdDto);
 
@@ -430,6 +432,7 @@ public class CaseServiceImplTest {
                 eq(Language.ENGLISH),
                 eq(uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API),
                 eq(uk.gov.ons.ctp.common.model.Channel.CC),
+                any(),
                 any(),
                 any(),
                 any(),
@@ -467,6 +470,7 @@ public class CaseServiceImplTest {
             caseCaptor.capture(),
             eq("1234"), // agent
             eq(questionnaireId),
+            eq(formType),
             isNull(), // accountServiceUrl
             isNull(),
             any()); // keystore


### PR DESCRIPTION
# Motivation and Context
FormType no longer hard coded as part of the JWE token payload but passed in to the method signature as part of the client request to create the JWE token.

# What has changed
FormType now returned in request to case service client and passed in request to EqLaunchService method to create  JWE token.

# How to test?
Unit tests amended to use passed in value. 

Can be tested running mock case api service, contact centre service and rabbitMQ locally and using Postman to hit contact centre launch URL e.g.
//localhost:8171/cases/03f58cb5-9af4-4d40-9d60-c124c5bddf09/launch?agentId=1111&individual=true 
