### PR TITLE
Update methods with new product reference fields

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>product-reference</artifactId>
-      <version>0.0.21</version>
+      <version>1.0.0</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -143,7 +143,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>product-reference</artifactId>
-      <version>1.0.0</version>
+      <version>1.0.1</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.61</version>
+      <version>0.0.62-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.62-SNAPSHOT</version>
+      <version>0.0.64</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpoint.java
@@ -51,8 +51,8 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
             requestDTO.getCaseType(),
             requestDTO.getRegion(),
             requestDTO.getDeliveryChannel(),
-            requestDTO.getIndividual());
-
+            requestDTO.getIndividual(),
+            requestDTO.getProductGroup());
     return ResponseEntity.ok(fulfilments);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpoint.java
@@ -51,7 +51,7 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
             requestDTO.getCaseType(),
             requestDTO.getRegion(),
             requestDTO.getDeliveryChannel(),
-            requestDTO.isIndividual());
+            requestDTO.getIndividual());
 
     return ResponseEntity.ok(fulfilments);
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpoint.java
@@ -48,7 +48,10 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
     log.with("requestParams", requestDTO).info("Entering GET getFulfilments");
     List<FulfilmentDTO> fulfilments =
         fulfilmentsService.getFulfilments(
-            requestDTO.getCaseType(), requestDTO.getRegion(), requestDTO.getDeliveryChannel());
+            requestDTO.getCaseType(),
+            requestDTO.getRegion(),
+            requestDTO.getDeliveryChannel(),
+            requestDTO.isIndividual());
 
     return ResponseEntity.ok(fulfilments);
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpoint.java
@@ -47,7 +47,8 @@ public final class FulfilmentsEndpoint implements CTPEndpoint {
       throws CTPException {
     log.with("requestParams", requestDTO).info("Entering GET getFulfilments");
     List<FulfilmentDTO> fulfilments =
-        fulfilmentsService.getFulfilments(requestDTO.getCaseType(), requestDTO.getRegion());
+        fulfilmentsService.getFulfilments(
+            requestDTO.getCaseType(), requestDTO.getRegion(), requestDTO.getDeliveryChannel());
 
     return ResponseEntity.ok(fulfilments);
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/FulfilmentsService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/FulfilmentsService.java
@@ -3,9 +3,11 @@ package uk.gov.ons.ctp.integration.contactcentresvc.service;
 import java.util.List;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseType;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.FulfilmentDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
 
 public interface FulfilmentsService {
-  List<FulfilmentDTO> getFulfilments(CaseType caseType, Region region) throws CTPException;
+  List<FulfilmentDTO> getFulfilments(
+      CaseType caseType, Region region, DeliveryChannel deliveryChannel) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/FulfilmentsService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/FulfilmentsService.java
@@ -9,5 +9,6 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
 
 public interface FulfilmentsService {
   List<FulfilmentDTO> getFulfilments(
-      CaseType caseType, Region region, DeliveryChannel deliveryChannel) throws CTPException;
+      CaseType caseType, Region region, DeliveryChannel deliveryChannel, boolean individual)
+      throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/FulfilmentsService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/FulfilmentsService.java
@@ -9,6 +9,6 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
 
 public interface FulfilmentsService {
   List<FulfilmentDTO> getFulfilments(
-      CaseType caseType, Region region, DeliveryChannel deliveryChannel, boolean individual)
+      CaseType caseType, Region region, DeliveryChannel deliveryChannel, Boolean individual)
       throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/FulfilmentsService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/FulfilmentsService.java
@@ -5,10 +5,15 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseType;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.FulfilmentDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.ProductGroup;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
 
 public interface FulfilmentsService {
   List<FulfilmentDTO> getFulfilments(
-      CaseType caseType, Region region, DeliveryChannel deliveryChannel, Boolean individual)
+      CaseType caseType,
+      Region region,
+      DeliveryChannel deliveryChannel,
+      Boolean individual,
+      ProductGroup productGroup)
       throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
 import static uk.gov.ons.ctp.integration.contactcentresvc.utility.Constants.UNKNOWN_UUID;
-
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
@@ -58,22 +57,28 @@ import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchService;
 @Configuration
 public class CaseServiceImpl implements CaseService {
 
-  @Autowired private EventPublisher publisher;
+  @Autowired
+  private EventPublisher publisher;
 
   private static final Logger log = LoggerFactory.getLogger(CaseServiceImpl.class);
   private static final String RESPONDENT_REFUSAL_TYPE = "HARD_REFUSAL";
 
-  @Autowired private AppConfig appConfig;
+  @Autowired
+  private AppConfig appConfig;
 
-  @Autowired private CaseServiceClientServiceImpl caseServiceClient;
+  @Autowired
+  private CaseServiceClientServiceImpl caseServiceClient;
 
-  @Autowired private ProductReference productReference;
+  @Autowired
+  private ProductReference productReference;
 
   private MapperFacade caseDTOMapper = new CCSvcBeanMapper();
 
-  @Autowired private EqLaunchService eqLaunchService;
+  @Autowired
+  private EqLaunchService eqLaunchService;
 
-  @Autowired private EventPublisher eventPublisher;
+  @Autowired
+  private EventPublisher eventPublisher;
 
   public ResponseDTO fulfilmentRequestByPost(PostalFulfilmentRequestDTO requestBodyDTO)
       throws CTPException {
@@ -88,14 +93,10 @@ public class CaseServiceImpl implements CaseService {
     contact.setForename(requestBodyDTO.getForename());
     contact.setSurname(requestBodyDTO.getSurname());
 
-    FulfilmentRequest fulfilmentRequestPayload =
-        createFulfilmentRequestPayload(
-            requestBodyDTO.getFulfilmentCode(), DeliveryChannel.POST, caseId, contact);
+    FulfilmentRequest fulfilmentRequestPayload = createFulfilmentRequestPayload(
+        requestBodyDTO.getFulfilmentCode(), DeliveryChannel.POST, caseId, contact);
 
-    publisher.sendEvent(
-        EventType.FULFILMENT_REQUESTED,
-        Source.CONTACT_CENTRE_API,
-        Channel.CC,
+    publisher.sendEvent(EventType.FULFILMENT_REQUESTED, Source.CONTACT_CENTRE_API, Channel.CC,
         fulfilmentRequestPayload);
 
     ResponseDTO response =
@@ -117,13 +118,9 @@ public class CaseServiceImpl implements CaseService {
     Contact contact = new Contact();
     contact.setTelNo(requestBodyDTO.getTelNo());
 
-    FulfilmentRequest fulfilmentRequestedPayload =
-        createFulfilmentRequestPayload(
-            requestBodyDTO.getFulfilmentCode(), DeliveryChannel.SMS, caseId, contact);
-    publisher.sendEvent(
-        EventType.FULFILMENT_REQUESTED,
-        Source.CONTACT_CENTRE_API,
-        Channel.CC,
+    FulfilmentRequest fulfilmentRequestedPayload = createFulfilmentRequestPayload(
+        requestBodyDTO.getFulfilmentCode(), DeliveryChannel.SMS, caseId, contact);
+    publisher.sendEvent(EventType.FULFILMENT_REQUESTED, Source.CONTACT_CENTRE_API, Channel.CC,
         fulfilmentRequestedPayload);
 
     ResponseDTO response =
@@ -145,8 +142,8 @@ public class CaseServiceImpl implements CaseService {
 
     // Only return Household cases
     if (!caseIsHouseholdOrCommunal(caseDetails.getCaseType())) {
-      throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, "Case is a not a household or communal case");
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+          "Case is a not a household or communal case");
     }
 
     // Convert from Case service to Contact Centre DTOs
@@ -160,8 +157,8 @@ public class CaseServiceImpl implements CaseService {
   }
 
   @Override
-  public List<CaseDTO> getCaseByUPRN(
-      UniquePropertyReferenceNumber uprn, CaseRequestDTO requestParamsDTO) {
+  public List<CaseDTO> getCaseByUPRN(UniquePropertyReferenceNumber uprn,
+      CaseRequestDTO requestParamsDTO) {
     log.with("uprn", uprn).debug("Fetching case details by UPRN");
 
     // Get the case details from the case service
@@ -170,11 +167,8 @@ public class CaseServiceImpl implements CaseService {
         caseServiceClient.getCaseByUprn(uprn.getValue(), getCaseEvents);
 
     // Only return Household cases
-    List<CaseContainerDTO> householdCases =
-        caseDetails
-            .parallelStream()
-            .filter(c -> caseIsHouseholdOrCommunal(c.getCaseType()))
-            .collect(Collectors.toList());
+    List<CaseContainerDTO> householdCases = caseDetails.parallelStream()
+        .filter(c -> caseIsHouseholdOrCommunal(c.getCaseType())).collect(Collectors.toList());
 
     // Convert from Case service to Contact Centre DTOs
     List<CaseDTO> caseServiceResponse = caseDTOMapper.mapAsList(householdCases, CaseDTO.class);
@@ -182,8 +176,7 @@ public class CaseServiceImpl implements CaseService {
     // Clean up the events before returning them
     caseServiceResponse.stream().forEach(c -> filterCaseEvents(c, getCaseEvents));
 
-    log.with("uprn", uprn)
-        .with("cases", caseServiceResponse.size())
+    log.with("uprn", uprn).with("cases", caseServiceResponse.size())
         .debug("Returning case details for UPRN");
 
     return caseServiceResponse;
@@ -200,8 +193,8 @@ public class CaseServiceImpl implements CaseService {
     // Only return Household cases
     if (!caseIsHouseholdOrCommunal(caseDetails.getCaseType())) {
       log.warn("Case is a not a household or communal case");
-      throw new ResponseStatusException(
-          HttpStatus.FORBIDDEN, "Case is a not a household or communal case");
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
+          "Case is a not a household or communal case");
     }
 
     // Convert from Case service to Contact Centre DTOs
@@ -221,8 +214,7 @@ public class CaseServiceImpl implements CaseService {
     if (requestBodyDTO.getDateTime() != null) {
       reportedDateTime = DateTimeUtil.formatDate(requestBodyDTO.getDateTime());
     }
-    log.with("caseId", caseId)
-        .with("reportedDateTime", reportedDateTime)
+    log.with("caseId", caseId).with("reportedDateTime", reportedDateTime)
         .debug("Processing refusal for case with reported dateTime");
 
     // Create and publish a respondent refusal event
@@ -230,15 +222,13 @@ public class CaseServiceImpl implements CaseService {
     RespondentRefusalDetails refusalPayload =
         createRespondentRefusalPayload(refusalCaseId, requestBodyDTO);
 
-    publisher.sendEvent(
-        EventType.REFUSAL_RECEIVED, Source.CONTACT_CENTRE_API, Channel.CC, refusalPayload);
+    publisher.sendEvent(EventType.REFUSAL_RECEIVED, Source.CONTACT_CENTRE_API, Channel.CC,
+        refusalPayload);
 
     // Build response
     ResponseDTO response =
-        ResponseDTO.builder()
-            .id(caseId == null ? UNKNOWN_UUID : caseId.toString())
-            .dateTime(DateTimeUtil.nowUTC())
-            .build();
+        ResponseDTO.builder().id(caseId == null ? UNKNOWN_UUID : caseId.toString())
+            .dateTime(DateTimeUtil.nowUTC()).build();
 
     log.with("caseId", caseId).debug("Returning refusal response for case");
 
@@ -248,8 +238,7 @@ public class CaseServiceImpl implements CaseService {
   @Override
   public String getLaunchURLForCaseId(final UUID caseId, LaunchRequestDTO requestParamsDTO)
       throws CTPException {
-    log.with("caseId", caseId)
-        .with("request", requestParamsDTO)
+    log.with("caseId", caseId).with("request", requestParamsDTO)
         .debug("Processing request to create launch URL");
 
     // Validate case known and is for CE or HH
@@ -279,17 +268,10 @@ public class CaseServiceImpl implements CaseService {
     // Finally, build the url needed to launch the survey
     String encryptedPayload = "";
     try {
-      encryptedPayload =
-          eqLaunchService.getEqLaunchJwe(
-              Language.ENGLISH,
-              uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API,
-              uk.gov.ons.ctp.common.model.Channel.CC,
-              caseDetails,
-              requestParamsDTO.getAgentId(),
-              questionnaireId,
-              null,
-              null,
-              appConfig.getKeystore());
+      encryptedPayload = eqLaunchService.getEqLaunchJwe(Language.ENGLISH,
+          uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API,
+          uk.gov.ons.ctp.common.model.Channel.CC, caseDetails, requestParamsDTO.getAgentId(),
+          questionnaireId, null, null, appConfig.getKeystore());
     } catch (CTPException e) {
       log.with(e).error("Failed to create JWE payload for eq launch");
       throw e;
@@ -306,24 +288,16 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private void publishSurveyLaunchedEvent(UUID caseId, String questionnaireId, String agentId) {
-    log.with("questionnaireId", questionnaireId)
-        .with("caseId", caseId)
-        .with("agentId", agentId)
+    log.with("questionnaireId", questionnaireId).with("caseId", caseId).with("agentId", agentId)
         .info("Generating SurveyLaunched event");
 
-    SurveyLaunchedResponse response =
-        SurveyLaunchedResponse.builder()
-            .questionnaireId(questionnaireId)
-            .caseId(caseId)
-            .agentId(agentId)
-            .build();
+    SurveyLaunchedResponse response = SurveyLaunchedResponse.builder()
+        .questionnaireId(questionnaireId).caseId(caseId).agentId(agentId).build();
 
-    String transactionId =
-        eventPublisher.sendEvent(
-            EventType.SURVEY_LAUNCHED, Source.CONTACT_CENTRE_API, Channel.CC, response);
+    String transactionId = eventPublisher.sendEvent(EventType.SURVEY_LAUNCHED,
+        Source.CONTACT_CENTRE_API, Channel.CC, response);
 
-    log.with("caseId", response.getCaseId())
-        .with("transactionId", transactionId)
+    log.with("caseId", response.getCaseId()).with("transactionId", transactionId)
         .debug("SurveyLaunch event published");
   }
 
@@ -332,12 +306,9 @@ public class CaseServiceImpl implements CaseService {
       // Only return whitelisted events
       Set<String> whitelistedEventCategories =
           appConfig.getCaseServiceSettings().getWhitelistedEventCategories();
-      List<CaseEventDTO> filteredEvents =
-          caseDTO
-              .getCaseEvents()
-              .stream()
-              .filter(e -> whitelistedEventCategories.contains(e.getCategory()))
-              .collect(Collectors.toList());
+      List<CaseEventDTO> filteredEvents = caseDTO.getCaseEvents().stream()
+          .filter(e -> whitelistedEventCategories.contains(e.getCategory()))
+          .collect(Collectors.toList());
       caseDTO.setCaseEvents(filteredEvents);
     } else {
       // Caller doesn't want any event data
@@ -345,9 +316,9 @@ public class CaseServiceImpl implements CaseService {
     }
   }
 
-  private boolean caseIsHouseholdOrCommunal(String caseTypeString) {
-    return caseTypeString.equals(CaseType.HH.name()) || caseTypeString.equals(CaseType.CE.name());
-  }
+   private boolean caseIsHouseholdOrCommunal(String caseTypeString) {
+   return caseTypeString.equals(CaseType.HH.name()) || caseTypeString.equals(CaseType.CE.name());
+   }
 
   /**
    * create a contact centre fulfilment request event
@@ -358,9 +329,8 @@ public class CaseServiceImpl implements CaseService {
    * @return the request event to be delivered to the events exchange
    * @throws CTPException the requested product is invalid for the parameters given
    */
-  private FulfilmentRequest createFulfilmentRequestPayload(
-      String fulfilmentCode, DeliveryChannel deliveryChannel, UUID caseId, Contact contact)
-      throws CTPException {
+  private FulfilmentRequest createFulfilmentRequestPayload(String fulfilmentCode,
+      DeliveryChannel deliveryChannel, UUID caseId, Contact contact) throws CTPException {
     log.with(fulfilmentCode)
         .debug("Entering createFulfilmentEvent method in class CaseServiceImpl");
 
@@ -369,14 +339,12 @@ public class CaseServiceImpl implements CaseService {
     Product product = findProduct(fulfilmentCode, deliveryChannel, region);
 
     if (deliveryChannel.equals(DeliveryChannel.POST)) {
-      if (!caseIsHouseholdOrCommunal(product.getCaseType().name())) {
-        if (StringUtils.isBlank(contact.getTitle())
-            || StringUtils.isBlank(contact.getForename())
+      if (product.getIndividual()) {
+        if (StringUtils.isBlank(contact.getTitle()) || StringUtils.isBlank(contact.getForename())
             || StringUtils.isBlank(contact.getSurname())) {
 
           log.warn("Individual fields are required for the requested fulfilment");
-          throw new CTPException(
-              Fault.BAD_REQUEST,
+          throw new CTPException(Fault.BAD_REQUEST,
               "The fulfilment is for an individual so none of the following fields can be empty: "
                   + "'title', 'forename' and 'surname'");
         }
@@ -385,7 +353,7 @@ public class CaseServiceImpl implements CaseService {
 
     // Set up the event payload request
     FulfilmentRequest fulfilmentRequest = new FulfilmentRequest();
-    if (product.getCaseType().equals(Product.CaseType.HI)) {
+    if (product.getIndividual()) {
       fulfilmentRequest.setIndividualCaseId(UUID.randomUUID().toString());
     }
 
@@ -402,24 +370,17 @@ public class CaseServiceImpl implements CaseService {
    * @param fulfilmentCode the code for the product requested
    * @param deliveryChannel how should the fulfilment be delivered
    * @param region identifies the region of the household case the fulfilment is for - used to
-   *     confirm the requested products eligibility
+   *        confirm the requested products eligibility
    * @return the matching product
    * @throws CTPException the product could not found or is ineligible for the given parameters
    */
-  private Product findProduct(
-      String fulfilmentCode, Product.DeliveryChannel deliveryChannel, Product.Region region)
-      throws CTPException {
-    log.with(fulfilmentCode)
-        .with(deliveryChannel)
-        .with(region)
+  private Product findProduct(String fulfilmentCode, Product.DeliveryChannel deliveryChannel,
+      Product.Region region) throws CTPException {
+    log.with(fulfilmentCode).with(deliveryChannel).with(region)
         .debug("Passing fulfilmentCode, deliveryChannel, and region, into findProduct method.");
-    Product searchCriteria =
-        Product.builder()
-            .fulfilmentCode(fulfilmentCode)
-            .requestChannels(Arrays.asList(Product.RequestChannel.CC))
-            .deliveryChannel(deliveryChannel)
-            .regions(Arrays.asList(region))
-            .build();
+    Product searchCriteria = Product.builder().fulfilmentCode(fulfilmentCode)
+        .requestChannels(Arrays.asList(Product.RequestChannel.CC)).deliveryChannel(deliveryChannel)
+        .regions(Arrays.asList(region)).build();
     List<Product> products = productReference.searchProducts(searchCriteria);
     if (products.size() == 0) {
       log.with("searchCriteria", searchCriteria).warn("Compatible product cannot be found");
@@ -433,13 +394,13 @@ public class CaseServiceImpl implements CaseService {
    * Create a case refusal event.
    *
    * @param caseId is the UUID for the case, or null if the endpoint was invoked with a caseId of
-   *     'unknown'.
+   *        'unknown'.
    * @param refusalRequest holds the details about the refusal.
    * @return the request event to be delivered to the events exchange.
    * @throws CTPException if there is a failure.
    */
-  private RespondentRefusalDetails createRespondentRefusalPayload(
-      UUID caseId, RefusalRequestDTO refusalRequest) throws CTPException {
+  private RespondentRefusalDetails createRespondentRefusalPayload(UUID caseId,
+      RefusalRequestDTO refusalRequest) throws CTPException {
 
     // Create message payload
     RespondentRefusalDetails refusal = new RespondentRefusalDetails();

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
 import static uk.gov.ons.ctp.integration.contactcentresvc.utility.Constants.UNKNOWN_UUID;
+
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
@@ -57,28 +58,22 @@ import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchService;
 @Configuration
 public class CaseServiceImpl implements CaseService {
 
-  @Autowired
-  private EventPublisher publisher;
+  @Autowired private EventPublisher publisher;
 
   private static final Logger log = LoggerFactory.getLogger(CaseServiceImpl.class);
   private static final String RESPONDENT_REFUSAL_TYPE = "HARD_REFUSAL";
 
-  @Autowired
-  private AppConfig appConfig;
+  @Autowired private AppConfig appConfig;
 
-  @Autowired
-  private CaseServiceClientServiceImpl caseServiceClient;
+  @Autowired private CaseServiceClientServiceImpl caseServiceClient;
 
-  @Autowired
-  private ProductReference productReference;
+  @Autowired private ProductReference productReference;
 
   private MapperFacade caseDTOMapper = new CCSvcBeanMapper();
 
-  @Autowired
-  private EqLaunchService eqLaunchService;
+  @Autowired private EqLaunchService eqLaunchService;
 
-  @Autowired
-  private EventPublisher eventPublisher;
+  @Autowired private EventPublisher eventPublisher;
 
   public ResponseDTO fulfilmentRequestByPost(PostalFulfilmentRequestDTO requestBodyDTO)
       throws CTPException {
@@ -93,10 +88,14 @@ public class CaseServiceImpl implements CaseService {
     contact.setForename(requestBodyDTO.getForename());
     contact.setSurname(requestBodyDTO.getSurname());
 
-    FulfilmentRequest fulfilmentRequestPayload = createFulfilmentRequestPayload(
-        requestBodyDTO.getFulfilmentCode(), DeliveryChannel.POST, caseId, contact);
+    FulfilmentRequest fulfilmentRequestPayload =
+        createFulfilmentRequestPayload(
+            requestBodyDTO.getFulfilmentCode(), DeliveryChannel.POST, caseId, contact);
 
-    publisher.sendEvent(EventType.FULFILMENT_REQUESTED, Source.CONTACT_CENTRE_API, Channel.CC,
+    publisher.sendEvent(
+        EventType.FULFILMENT_REQUESTED,
+        Source.CONTACT_CENTRE_API,
+        Channel.CC,
         fulfilmentRequestPayload);
 
     ResponseDTO response =
@@ -118,9 +117,13 @@ public class CaseServiceImpl implements CaseService {
     Contact contact = new Contact();
     contact.setTelNo(requestBodyDTO.getTelNo());
 
-    FulfilmentRequest fulfilmentRequestedPayload = createFulfilmentRequestPayload(
-        requestBodyDTO.getFulfilmentCode(), DeliveryChannel.SMS, caseId, contact);
-    publisher.sendEvent(EventType.FULFILMENT_REQUESTED, Source.CONTACT_CENTRE_API, Channel.CC,
+    FulfilmentRequest fulfilmentRequestedPayload =
+        createFulfilmentRequestPayload(
+            requestBodyDTO.getFulfilmentCode(), DeliveryChannel.SMS, caseId, contact);
+    publisher.sendEvent(
+        EventType.FULFILMENT_REQUESTED,
+        Source.CONTACT_CENTRE_API,
+        Channel.CC,
         fulfilmentRequestedPayload);
 
     ResponseDTO response =
@@ -142,8 +145,8 @@ public class CaseServiceImpl implements CaseService {
 
     // Only return Household cases
     if (!caseIsHouseholdOrCommunal(caseDetails.getCaseType())) {
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-          "Case is a not a household or communal case");
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "Case is a not a household or communal case");
     }
 
     // Convert from Case service to Contact Centre DTOs
@@ -157,8 +160,8 @@ public class CaseServiceImpl implements CaseService {
   }
 
   @Override
-  public List<CaseDTO> getCaseByUPRN(UniquePropertyReferenceNumber uprn,
-      CaseRequestDTO requestParamsDTO) {
+  public List<CaseDTO> getCaseByUPRN(
+      UniquePropertyReferenceNumber uprn, CaseRequestDTO requestParamsDTO) {
     log.with("uprn", uprn).debug("Fetching case details by UPRN");
 
     // Get the case details from the case service
@@ -167,8 +170,11 @@ public class CaseServiceImpl implements CaseService {
         caseServiceClient.getCaseByUprn(uprn.getValue(), getCaseEvents);
 
     // Only return Household cases
-    List<CaseContainerDTO> householdCases = caseDetails.parallelStream()
-        .filter(c -> caseIsHouseholdOrCommunal(c.getCaseType())).collect(Collectors.toList());
+    List<CaseContainerDTO> householdCases =
+        caseDetails
+            .parallelStream()
+            .filter(c -> caseIsHouseholdOrCommunal(c.getCaseType()))
+            .collect(Collectors.toList());
 
     // Convert from Case service to Contact Centre DTOs
     List<CaseDTO> caseServiceResponse = caseDTOMapper.mapAsList(householdCases, CaseDTO.class);
@@ -176,7 +182,8 @@ public class CaseServiceImpl implements CaseService {
     // Clean up the events before returning them
     caseServiceResponse.stream().forEach(c -> filterCaseEvents(c, getCaseEvents));
 
-    log.with("uprn", uprn).with("cases", caseServiceResponse.size())
+    log.with("uprn", uprn)
+        .with("cases", caseServiceResponse.size())
         .debug("Returning case details for UPRN");
 
     return caseServiceResponse;
@@ -193,8 +200,8 @@ public class CaseServiceImpl implements CaseService {
     // Only return Household cases
     if (!caseIsHouseholdOrCommunal(caseDetails.getCaseType())) {
       log.warn("Case is a not a household or communal case");
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN,
-          "Case is a not a household or communal case");
+      throw new ResponseStatusException(
+          HttpStatus.FORBIDDEN, "Case is a not a household or communal case");
     }
 
     // Convert from Case service to Contact Centre DTOs
@@ -214,7 +221,8 @@ public class CaseServiceImpl implements CaseService {
     if (requestBodyDTO.getDateTime() != null) {
       reportedDateTime = DateTimeUtil.formatDate(requestBodyDTO.getDateTime());
     }
-    log.with("caseId", caseId).with("reportedDateTime", reportedDateTime)
+    log.with("caseId", caseId)
+        .with("reportedDateTime", reportedDateTime)
         .debug("Processing refusal for case with reported dateTime");
 
     // Create and publish a respondent refusal event
@@ -222,13 +230,15 @@ public class CaseServiceImpl implements CaseService {
     RespondentRefusalDetails refusalPayload =
         createRespondentRefusalPayload(refusalCaseId, requestBodyDTO);
 
-    publisher.sendEvent(EventType.REFUSAL_RECEIVED, Source.CONTACT_CENTRE_API, Channel.CC,
-        refusalPayload);
+    publisher.sendEvent(
+        EventType.REFUSAL_RECEIVED, Source.CONTACT_CENTRE_API, Channel.CC, refusalPayload);
 
     // Build response
     ResponseDTO response =
-        ResponseDTO.builder().id(caseId == null ? UNKNOWN_UUID : caseId.toString())
-            .dateTime(DateTimeUtil.nowUTC()).build();
+        ResponseDTO.builder()
+            .id(caseId == null ? UNKNOWN_UUID : caseId.toString())
+            .dateTime(DateTimeUtil.nowUTC())
+            .build();
 
     log.with("caseId", caseId).debug("Returning refusal response for case");
 
@@ -238,7 +248,8 @@ public class CaseServiceImpl implements CaseService {
   @Override
   public String getLaunchURLForCaseId(final UUID caseId, LaunchRequestDTO requestParamsDTO)
       throws CTPException {
-    log.with("caseId", caseId).with("request", requestParamsDTO)
+    log.with("caseId", caseId)
+        .with("request", requestParamsDTO)
         .debug("Processing request to create launch URL");
 
     // Validate case known and is for CE or HH
@@ -268,10 +279,17 @@ public class CaseServiceImpl implements CaseService {
     // Finally, build the url needed to launch the survey
     String encryptedPayload = "";
     try {
-      encryptedPayload = eqLaunchService.getEqLaunchJwe(Language.ENGLISH,
-          uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API,
-          uk.gov.ons.ctp.common.model.Channel.CC, caseDetails, requestParamsDTO.getAgentId(),
-          questionnaireId, null, null, appConfig.getKeystore());
+      encryptedPayload =
+          eqLaunchService.getEqLaunchJwe(
+              Language.ENGLISH,
+              uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API,
+              uk.gov.ons.ctp.common.model.Channel.CC,
+              caseDetails,
+              requestParamsDTO.getAgentId(),
+              questionnaireId,
+              null,
+              null,
+              appConfig.getKeystore());
     } catch (CTPException e) {
       log.with(e).error("Failed to create JWE payload for eq launch");
       throw e;
@@ -288,16 +306,24 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private void publishSurveyLaunchedEvent(UUID caseId, String questionnaireId, String agentId) {
-    log.with("questionnaireId", questionnaireId).with("caseId", caseId).with("agentId", agentId)
+    log.with("questionnaireId", questionnaireId)
+        .with("caseId", caseId)
+        .with("agentId", agentId)
         .info("Generating SurveyLaunched event");
 
-    SurveyLaunchedResponse response = SurveyLaunchedResponse.builder()
-        .questionnaireId(questionnaireId).caseId(caseId).agentId(agentId).build();
+    SurveyLaunchedResponse response =
+        SurveyLaunchedResponse.builder()
+            .questionnaireId(questionnaireId)
+            .caseId(caseId)
+            .agentId(agentId)
+            .build();
 
-    String transactionId = eventPublisher.sendEvent(EventType.SURVEY_LAUNCHED,
-        Source.CONTACT_CENTRE_API, Channel.CC, response);
+    String transactionId =
+        eventPublisher.sendEvent(
+            EventType.SURVEY_LAUNCHED, Source.CONTACT_CENTRE_API, Channel.CC, response);
 
-    log.with("caseId", response.getCaseId()).with("transactionId", transactionId)
+    log.with("caseId", response.getCaseId())
+        .with("transactionId", transactionId)
         .debug("SurveyLaunch event published");
   }
 
@@ -306,9 +332,12 @@ public class CaseServiceImpl implements CaseService {
       // Only return whitelisted events
       Set<String> whitelistedEventCategories =
           appConfig.getCaseServiceSettings().getWhitelistedEventCategories();
-      List<CaseEventDTO> filteredEvents = caseDTO.getCaseEvents().stream()
-          .filter(e -> whitelistedEventCategories.contains(e.getCategory()))
-          .collect(Collectors.toList());
+      List<CaseEventDTO> filteredEvents =
+          caseDTO
+              .getCaseEvents()
+              .stream()
+              .filter(e -> whitelistedEventCategories.contains(e.getCategory()))
+              .collect(Collectors.toList());
       caseDTO.setCaseEvents(filteredEvents);
     } else {
       // Caller doesn't want any event data
@@ -316,9 +345,9 @@ public class CaseServiceImpl implements CaseService {
     }
   }
 
-   private boolean caseIsHouseholdOrCommunal(String caseTypeString) {
-   return caseTypeString.equals(CaseType.HH.name()) || caseTypeString.equals(CaseType.CE.name());
-   }
+  private boolean caseIsHouseholdOrCommunal(String caseTypeString) {
+    return caseTypeString.equals(CaseType.HH.name()) || caseTypeString.equals(CaseType.CE.name());
+  }
 
   /**
    * create a contact centre fulfilment request event
@@ -329,8 +358,9 @@ public class CaseServiceImpl implements CaseService {
    * @return the request event to be delivered to the events exchange
    * @throws CTPException the requested product is invalid for the parameters given
    */
-  private FulfilmentRequest createFulfilmentRequestPayload(String fulfilmentCode,
-      DeliveryChannel deliveryChannel, UUID caseId, Contact contact) throws CTPException {
+  private FulfilmentRequest createFulfilmentRequestPayload(
+      String fulfilmentCode, DeliveryChannel deliveryChannel, UUID caseId, Contact contact)
+      throws CTPException {
     log.with(fulfilmentCode)
         .debug("Entering createFulfilmentEvent method in class CaseServiceImpl");
 
@@ -340,11 +370,13 @@ public class CaseServiceImpl implements CaseService {
 
     if (deliveryChannel.equals(DeliveryChannel.POST)) {
       if (product.getIndividual()) {
-        if (StringUtils.isBlank(contact.getTitle()) || StringUtils.isBlank(contact.getForename())
+        if (StringUtils.isBlank(contact.getTitle())
+            || StringUtils.isBlank(contact.getForename())
             || StringUtils.isBlank(contact.getSurname())) {
 
           log.warn("Individual fields are required for the requested fulfilment");
-          throw new CTPException(Fault.BAD_REQUEST,
+          throw new CTPException(
+              Fault.BAD_REQUEST,
               "The fulfilment is for an individual so none of the following fields can be empty: "
                   + "'title', 'forename' and 'surname'");
         }
@@ -370,17 +402,24 @@ public class CaseServiceImpl implements CaseService {
    * @param fulfilmentCode the code for the product requested
    * @param deliveryChannel how should the fulfilment be delivered
    * @param region identifies the region of the household case the fulfilment is for - used to
-   *        confirm the requested products eligibility
+   *     confirm the requested products eligibility
    * @return the matching product
    * @throws CTPException the product could not found or is ineligible for the given parameters
    */
-  private Product findProduct(String fulfilmentCode, Product.DeliveryChannel deliveryChannel,
-      Product.Region region) throws CTPException {
-    log.with(fulfilmentCode).with(deliveryChannel).with(region)
+  private Product findProduct(
+      String fulfilmentCode, Product.DeliveryChannel deliveryChannel, Product.Region region)
+      throws CTPException {
+    log.with(fulfilmentCode)
+        .with(deliveryChannel)
+        .with(region)
         .debug("Passing fulfilmentCode, deliveryChannel, and region, into findProduct method.");
-    Product searchCriteria = Product.builder().fulfilmentCode(fulfilmentCode)
-        .requestChannels(Arrays.asList(Product.RequestChannel.CC)).deliveryChannel(deliveryChannel)
-        .regions(Arrays.asList(region)).build();
+    Product searchCriteria =
+        Product.builder()
+            .fulfilmentCode(fulfilmentCode)
+            .requestChannels(Arrays.asList(Product.RequestChannel.CC))
+            .deliveryChannel(deliveryChannel)
+            .regions(Arrays.asList(region))
+            .build();
     List<Product> products = productReference.searchProducts(searchCriteria);
     if (products.size() == 0) {
       log.with("searchCriteria", searchCriteria).warn("Compatible product cannot be found");
@@ -394,13 +433,13 @@ public class CaseServiceImpl implements CaseService {
    * Create a case refusal event.
    *
    * @param caseId is the UUID for the case, or null if the endpoint was invoked with a caseId of
-   *        'unknown'.
+   *     'unknown'.
    * @param refusalRequest holds the details about the refusal.
    * @return the request event to be delivered to the events exchange.
    * @throws CTPException if there is a failure.
    */
-  private RespondentRefusalDetails createRespondentRefusalPayload(UUID caseId,
-      RefusalRequestDTO refusalRequest) throws CTPException {
+  private RespondentRefusalDetails createRespondentRefusalPayload(
+      UUID caseId, RefusalRequestDTO refusalRequest) throws CTPException {
 
     // Create message payload
     RespondentRefusalDetails refusal = new RespondentRefusalDetails();

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -368,8 +368,8 @@ public class CaseServiceImpl implements CaseService {
     log.with(fulfilmentCode)
         .debug("Entering createFulfilmentEvent method in class CaseServiceImpl");
 
-    Region region =
-        Region.valueOf(caseServiceClient.getCaseById(caseId, false).getRegion().substring(0, 1));
+    CaseContainerDTO caze = caseServiceClient.getCaseById(caseId, false);
+    Region region = Region.valueOf(caze.getRegion().substring(0, 1));
     Product product = findProduct(fulfilmentCode, deliveryChannel, region);
 
     if (deliveryChannel.equals(DeliveryChannel.POST)) {
@@ -387,9 +387,11 @@ public class CaseServiceImpl implements CaseService {
       }
     }
 
-    // Set up the event payload request
     FulfilmentRequest fulfilmentRequest = new FulfilmentRequest();
-    if (product.getIndividual()) {
+    // create a new indiv id only if the parent case is an HH and the product requested is for an
+    // indiv
+    // SPG and CE indiv product requests do not need an indiv id creating
+    if (CaseType.HH.name().equals(caze.getCaseType()) && product.getIndividual()) {
       fulfilmentRequest.setIndividualCaseId(UUID.randomUUID().toString());
     }
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
@@ -25,7 +25,8 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
 
   @Override
   public List<FulfilmentDTO> getFulfilments(
-      CaseType caseType, Region region, DeliveryChannel deliveryChannel) throws CTPException {
+      CaseType caseType, Region region, DeliveryChannel deliveryChannel, boolean individual)
+      throws CTPException {
     Product example = new Product();
     example.setCaseTypes(
         caseType == null ? null : Arrays.asList(Product.CaseType.valueOf(caseType.name())));
@@ -33,6 +34,7 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
         region == null ? null : Arrays.asList(Product.Region.valueOf(region.name())));
     example.setRequestChannels(Arrays.asList(RequestChannel.CC));
     example.setDeliveryChannel(Product.DeliveryChannel.valueOf(deliveryChannel.name()));
+    example.setIndividual(individual);
     return mapperFacade.mapAsList(productReference.searchProducts(example), FulfilmentDTO.class);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
@@ -25,7 +25,7 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
   @Override
   public List<FulfilmentDTO> getFulfilments(CaseType caseType, Region region) throws CTPException {
     Product example = new Product();
-    example.setCaseType(caseType == null ? null : Product.CaseType.valueOf(caseType.name()));
+    example.setCaseTypes(caseType == null ? null : Arrays.asList(Product.CaseType.valueOf(caseType.name())));
     example.setRegions(
         region == null ? null : Arrays.asList(Product.Region.valueOf(region.name())));
     example.setRequestChannels(Arrays.asList(RequestChannel.CC));

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
@@ -25,7 +25,8 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
   @Override
   public List<FulfilmentDTO> getFulfilments(CaseType caseType, Region region) throws CTPException {
     Product example = new Product();
-    example.setCaseTypes(caseType == null ? null : Arrays.asList(Product.CaseType.valueOf(caseType.name())));
+    example.setCaseTypes(
+        caseType == null ? null : Arrays.asList(Product.CaseType.valueOf(caseType.name())));
     example.setRegions(
         region == null ? null : Arrays.asList(Product.Region.valueOf(region.name())));
     example.setRequestChannels(Arrays.asList(RequestChannel.CC));

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
@@ -25,7 +25,7 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
 
   @Override
   public List<FulfilmentDTO> getFulfilments(
-      CaseType caseType, Region region, DeliveryChannel deliveryChannel, boolean individual)
+      CaseType caseType, Region region, DeliveryChannel deliveryChannel, Boolean individual)
       throws CTPException {
     Product example = new Product();
     example.setCaseTypes(
@@ -33,7 +33,8 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
     example.setRegions(
         region == null ? null : Arrays.asList(Product.Region.valueOf(region.name())));
     example.setRequestChannels(Arrays.asList(RequestChannel.CC));
-    example.setDeliveryChannel(Product.DeliveryChannel.valueOf(deliveryChannel.name()));
+    example.setDeliveryChannel(
+        deliveryChannel == null ? null : Product.DeliveryChannel.valueOf(deliveryChannel.name()));
     example.setIndividual(individual);
     return mapperFacade.mapAsList(productReference.searchProducts(example), FulfilmentDTO.class);
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
@@ -11,6 +11,7 @@ import uk.gov.ons.ctp.integration.common.product.ProductReference;
 import uk.gov.ons.ctp.integration.common.product.model.Product;
 import uk.gov.ons.ctp.integration.common.product.model.Product.RequestChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseType;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.FulfilmentDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.FulfilmentsService;
@@ -23,7 +24,8 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
   @Autowired private MapperFacade mapperFacade;
 
   @Override
-  public List<FulfilmentDTO> getFulfilments(CaseType caseType, Region region) throws CTPException {
+  public List<FulfilmentDTO> getFulfilments(
+      CaseType caseType, Region region, DeliveryChannel deliveryChannel) throws CTPException {
     Product example = new Product();
     example.setCaseTypes(
         caseType == null ? null : Arrays.asList(Product.CaseType.valueOf(caseType.name())));

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
@@ -32,6 +32,7 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
     example.setRegions(
         region == null ? null : Arrays.asList(Product.Region.valueOf(region.name())));
     example.setRequestChannels(Arrays.asList(RequestChannel.CC));
+    example.setDeliveryChannel(Product.DeliveryChannel.valueOf(deliveryChannel.name()));
     return mapperFacade.mapAsList(productReference.searchProducts(example), FulfilmentDTO.class);
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentsServiceImpl.java
@@ -13,6 +13,7 @@ import uk.gov.ons.ctp.integration.common.product.model.Product.RequestChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseType;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.FulfilmentDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.ProductGroup;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.FulfilmentsService;
 
@@ -25,7 +26,11 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
 
   @Override
   public List<FulfilmentDTO> getFulfilments(
-      CaseType caseType, Region region, DeliveryChannel deliveryChannel, Boolean individual)
+      CaseType caseType,
+      Region region,
+      DeliveryChannel deliveryChannel,
+      Boolean individual,
+      ProductGroup productGroup)
       throws CTPException {
     Product example = new Product();
     example.setCaseTypes(
@@ -36,6 +41,8 @@ public class FulfilmentsServiceImpl implements FulfilmentsService {
     example.setDeliveryChannel(
         deliveryChannel == null ? null : Product.DeliveryChannel.valueOf(deliveryChannel.name()));
     example.setIndividual(individual);
+    example.setProductGroup(
+        productGroup == null ? null : Product.ProductGroup.valueOf(productGroup.name()));
     return mapperFacade.mapAsList(productReference.searchProducts(example), FulfilmentDTO.class);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpointTest.java
@@ -2,7 +2,7 @@ package uk.gov.ons.ctp.integration.contactcentresvc.endpoint;
 
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
+//import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.ons.ctp.common.MvcHelper.getJson;
@@ -31,6 +31,7 @@ public final class FulfilmentsEndpointTest {
 
   private static final String PARAM_CASE_TYPE = "caseType";
   private static final String PARAM_REGION = "region";
+  private static final String PARAM_INDIVIDUAL = "individual";
 
   private static final String FULFILMENT_CODE_1 = "P1";
   private static final String LANGUAGE_1 = "eng";
@@ -65,7 +66,7 @@ public final class FulfilmentsEndpointTest {
   @Test
   public void fulfilmentsGoodRequestNoParams() throws Exception {
     List<FulfilmentDTO> testCaseDTO = createResponseFulfilmentDTO();
-    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), anyBoolean()))
+    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), any()))
         .thenReturn(testCaseDTO);
 
     ResultActions actions = mockMvc.perform(getJson("/fulfilments"));
@@ -77,12 +78,12 @@ public final class FulfilmentsEndpointTest {
   @Test
   public void fulfilmentsGoodRequestAllParams() throws Exception {
     List<FulfilmentDTO> testCaseDTO = createResponseFulfilmentDTO();
-    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), anyBoolean()))
+    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), any()))
         .thenReturn(testCaseDTO);
 
     ResultActions actions =
         mockMvc.perform(
-            getJson("/fulfilments").param(PARAM_CASE_TYPE, "HI").param(PARAM_REGION, "E"));
+            getJson("/fulfilments").param(PARAM_REGION, "E").param(PARAM_INDIVIDUAL, "true"));
     actions.andExpect(status().isOk());
 
     verifyStructureOfFulfilmentDTO(actions);

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpointTest.java
@@ -66,7 +66,7 @@ public final class FulfilmentsEndpointTest {
   @Test
   public void fulfilmentsGoodRequestNoParams() throws Exception {
     List<FulfilmentDTO> testCaseDTO = createResponseFulfilmentDTO();
-    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), any()))
+    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), any(), any()))
         .thenReturn(testCaseDTO);
 
     ResultActions actions = mockMvc.perform(getJson("/fulfilments"));
@@ -78,7 +78,7 @@ public final class FulfilmentsEndpointTest {
   @Test
   public void fulfilmentsGoodRequestAllParams() throws Exception {
     List<FulfilmentDTO> testCaseDTO = createResponseFulfilmentDTO();
-    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), any()))
+    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), any(), any()))
         .thenReturn(testCaseDTO);
 
     ResultActions actions =

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpointTest.java
@@ -2,6 +2,7 @@ package uk.gov.ons.ctp.integration.contactcentresvc.endpoint;
 
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.ons.ctp.common.MvcHelper.getJson;
@@ -64,7 +65,8 @@ public final class FulfilmentsEndpointTest {
   @Test
   public void fulfilmentsGoodRequestNoParams() throws Exception {
     List<FulfilmentDTO> testCaseDTO = createResponseFulfilmentDTO();
-    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any())).thenReturn(testCaseDTO);
+    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), anyBoolean()))
+        .thenReturn(testCaseDTO);
 
     ResultActions actions = mockMvc.perform(getJson("/fulfilments"));
     actions.andExpect(status().isOk());
@@ -75,7 +77,8 @@ public final class FulfilmentsEndpointTest {
   @Test
   public void fulfilmentsGoodRequestAllParams() throws Exception {
     List<FulfilmentDTO> testCaseDTO = createResponseFulfilmentDTO();
-    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any())).thenReturn(testCaseDTO);
+    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any(), anyBoolean()))
+        .thenReturn(testCaseDTO);
 
     ResultActions actions =
         mockMvc.perform(

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/FulfilmentsEndpointTest.java
@@ -64,7 +64,7 @@ public final class FulfilmentsEndpointTest {
   @Test
   public void fulfilmentsGoodRequestNoParams() throws Exception {
     List<FulfilmentDTO> testCaseDTO = createResponseFulfilmentDTO();
-    Mockito.when(fulfilmentService.getFulfilments(any(), any())).thenReturn(testCaseDTO);
+    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any())).thenReturn(testCaseDTO);
 
     ResultActions actions = mockMvc.perform(getJson("/fulfilments"));
     actions.andExpect(status().isOk());
@@ -75,7 +75,7 @@ public final class FulfilmentsEndpointTest {
   @Test
   public void fulfilmentsGoodRequestAllParams() throws Exception {
     List<FulfilmentDTO> testCaseDTO = createResponseFulfilmentDTO();
-    Mockito.when(fulfilmentService.getFulfilments(any(), any())).thenReturn(testCaseDTO);
+    Mockito.when(fulfilmentService.getFulfilments(any(), any(), any())).thenReturn(testCaseDTO);
 
     ResultActions actions =
         mockMvc.perform(

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -114,39 +114,39 @@ public class CaseServiceImplTest {
   public void testFulfilmentRequestByPost_individualFailsWithNullContactDetails() throws Exception {
     // All of the following fail validation because one of the contact detail fields is always null
     // or empty
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HI, null, "John", "Smith");
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HI, "", "John", "Smith");
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HI, "Mr", null, "Smith");
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HI, "Mr", "", "Smith");
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HI, "Mr", "John", null);
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HI, "Mr", "John", "");
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), null, "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "", "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "Mr", null, "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "Mr", "", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "Mr", "John", null, true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "Mr", "John", "", true);
 
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CI, null, "John", "Smith");
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CI, "", "John", "Smith");
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CI, "Mr", null, "Smith");
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CI, "Mr", "", "Smith");
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CI, "Mr", "John", null);
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CI, "Mr", "John", "");
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), null, "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "", "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "Mr", null, "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "Mr", "", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "Mr", "John", null, true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "Mr", "John", "", true);
   }
 
   @Test
   public void testFulfilmentRequestByPost_nonIndividualAllowsNullContactDetails() throws Exception {
     // Test that non-individual cases allow null/empty contact details
-    doFulfilmentRequestByPostSuccess(Product.CaseType.HH, null, null, null);
-    doFulfilmentRequestByPostSuccess(Product.CaseType.HH, "", "", "");
+    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.HH), null, null, null, false);
+    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.HH), "", "", "", false);
 
-    doFulfilmentRequestByPostSuccess(Product.CaseType.CE, null, null, null);
-    doFulfilmentRequestByPostSuccess(Product.CaseType.CE, "", "", "");
+    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.CE), null, null, null, false);
+    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.CE), "", "", "", false);
   }
 
   @Test
   public void testFulfilmentRequestByPostSuccess_withCaseTypeHH() throws Exception {
-    doFulfilmentRequestByPostSuccess(Product.CaseType.HH, "Mr", "Mickey", "Mouse");
+    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.HH), "Mr", "Mickey", "Mouse", false);
   }
-
+  
   @Test
-  public void testFulfilmentRequestByPostSuccess_withCaseTypeHI() throws Exception {
-    doFulfilmentRequestByPostSuccess(Product.CaseType.HI, "Mr", "Mickey", "Mouse");
+  public void testFulfilmentRequestByPostSuccess_withIndividualTrue() throws Exception {
+    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.HH), "Mr", "Mickey", "Mouse", true);
   }
 
   @Test
@@ -178,12 +178,12 @@ public class CaseServiceImplTest {
 
   @Test
   public void testFulfilmentRequestBySMSSuccess_withCaseTypeHH() throws Exception {
-    doFulfilmentRequestBySMSSuccess(Product.CaseType.HH);
+    doFulfilmentRequestBySMSSuccess(Arrays.asList(Product.CaseType.HH), false);
   }
 
   @Test
-  public void testFulfilmentRequestBySMSSuccess_withCaseTypeHI() throws Exception {
-    doFulfilmentRequestBySMSSuccess(Product.CaseType.HI);
+  public void testFulfilmentRequestBySMSSuccess_withIndividualTrue() throws Exception {
+    doFulfilmentRequestBySMSSuccess(Arrays.asList(Product.CaseType.HH), true);
   }
 
   @Test
@@ -724,9 +724,8 @@ public class CaseServiceImplTest {
   }
 
   private Product getProductFoundFixture(
-      Product.CaseType caseType, Product.DeliveryChannel deliveryChannel) {
-    return Product.builder()
-        .caseType(caseType)
+      List<Product.CaseType> caseTypes, Product.DeliveryChannel deliveryChannel, boolean individual) {
+    return Product.builder().caseTypes(caseTypes)
         .description("foobar")
         .fulfilmentCode("ABC123")
         .language("eng")
@@ -735,6 +734,7 @@ public class CaseServiceImplTest {
         .requestChannels(
             new ArrayList<Product.RequestChannel>(
                 List.of(Product.RequestChannel.CC, Product.RequestChannel.FIELD)))
+        .individual(individual)
         .build();
   }
 
@@ -749,7 +749,7 @@ public class CaseServiceImplTest {
   }
 
   private void doVerifyFulfilmentRequestByPostFailsValidation(
-      Product.CaseType caseType, String title, String forename, String surname) throws Exception {
+      List<Product.CaseType> caseTypes, String title, String forename, String surname, boolean individual) throws Exception {
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService =
         FixtureHelper.loadClassFixtures(CaseContainerDTO[].class).get(0);
@@ -765,7 +765,7 @@ public class CaseServiceImplTest {
             Product.DeliveryChannel.POST);
 
     // The mocked productReference will return this product
-    Product productFoundFixture = getProductFoundFixture(caseType, Product.DeliveryChannel.POST);
+    Product productFoundFixture = getProductFoundFixture(caseTypes, Product.DeliveryChannel.POST, individual);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -779,7 +779,7 @@ public class CaseServiceImplTest {
   }
 
   private void doFulfilmentRequestByPostSuccess(
-      Product.CaseType caseType, String title, String forename, String surname) throws Exception {
+      List<Product.CaseType> caseTypes, String title, String forename, String surname, boolean individual) throws Exception {
     Mockito.clearInvocations(publisher);
 
     // Build results to be returned from search
@@ -797,7 +797,7 @@ public class CaseServiceImplTest {
             Product.DeliveryChannel.POST);
 
     // The mocked productReference will return this product
-    Product productFoundFixture = getProductFoundFixture(caseType, Product.DeliveryChannel.POST);
+    Product productFoundFixture = getProductFoundFixture(caseTypes, Product.DeliveryChannel.POST, individual);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -833,7 +833,7 @@ public class CaseServiceImplTest {
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), actualFulfilmentRequest.getCaseId());
 
     // If the caseType is HI then the individualCaseId should be set, otherwise it should be empty.
-    if (caseType == Product.CaseType.HI) {
+    if (individual) {
       assertNotNull(actualFulfilmentRequest.getIndividualCaseId());
     } else {
       assertEquals(null, actualFulfilmentRequest.getIndividualCaseId());
@@ -847,7 +847,7 @@ public class CaseServiceImplTest {
     assertEquals(null, actualContact.getTelNo());
   }
 
-  private void doFulfilmentRequestBySMSSuccess(Product.CaseType caseType) throws Exception {
+  private void doFulfilmentRequestBySMSSuccess(List<Product.CaseType> caseTypes, boolean individual) throws Exception {
 
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService =
@@ -863,7 +863,7 @@ public class CaseServiceImplTest {
             Product.DeliveryChannel.SMS);
 
     // The mocked productReference will return this product
-    Product productFoundFixture = getProductFoundFixture(caseType, Product.DeliveryChannel.SMS);
+    Product productFoundFixture = getProductFoundFixture(caseTypes, Product.DeliveryChannel.SMS, individual);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -899,7 +899,7 @@ public class CaseServiceImplTest {
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), actualFulfilmentRequest.getCaseId());
 
     // If the caseType is HI then the individualCaseId should be set, otherwise it should be empty.
-    if (caseType == Product.CaseType.HI) {
+    if (individual) {
       assertNotNull(actualFulfilmentRequest.getIndividualCaseId());
     } else {
       assertEquals(null, actualFulfilmentRequest.getIndividualCaseId());

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -114,19 +114,31 @@ public class CaseServiceImplTest {
   public void testFulfilmentRequestByPost_individualFailsWithNullContactDetails() throws Exception {
     // All of the following fail validation because one of the contact detail fields is always null
     // or empty
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), null, "John", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "", "John", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "Mr", null, "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "Mr", "", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "Mr", "John", null, true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.HH), "Mr", "John", "", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.HH), null, "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.HH), "", "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.HH), "Mr", null, "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.HH), "Mr", "", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.HH), "Mr", "John", null, true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.HH), "Mr", "John", "", true);
 
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), null, "John", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "", "John", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "Mr", null, "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "Mr", "", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "Mr", "John", null, true);
-    doVerifyFulfilmentRequestByPostFailsValidation(Arrays.asList(Product.CaseType.CE), "Mr", "John", "", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.CE), null, "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.CE), "", "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.CE), "Mr", null, "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.CE), "Mr", "", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.CE), "Mr", "John", null, true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Arrays.asList(Product.CaseType.CE), "Mr", "John", "", true);
   }
 
   @Test
@@ -141,12 +153,14 @@ public class CaseServiceImplTest {
 
   @Test
   public void testFulfilmentRequestByPostSuccess_withCaseTypeHH() throws Exception {
-    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.HH), "Mr", "Mickey", "Mouse", false);
+    doFulfilmentRequestByPostSuccess(
+        Arrays.asList(Product.CaseType.HH), "Mr", "Mickey", "Mouse", false);
   }
-  
+
   @Test
   public void testFulfilmentRequestByPostSuccess_withIndividualTrue() throws Exception {
-    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.HH), "Mr", "Mickey", "Mouse", true);
+    doFulfilmentRequestByPostSuccess(
+        Arrays.asList(Product.CaseType.HH), "Mr", "Mickey", "Mouse", true);
   }
 
   @Test
@@ -724,8 +738,11 @@ public class CaseServiceImplTest {
   }
 
   private Product getProductFoundFixture(
-      List<Product.CaseType> caseTypes, Product.DeliveryChannel deliveryChannel, boolean individual) {
-    return Product.builder().caseTypes(caseTypes)
+      List<Product.CaseType> caseTypes,
+      Product.DeliveryChannel deliveryChannel,
+      boolean individual) {
+    return Product.builder()
+        .caseTypes(caseTypes)
         .description("foobar")
         .fulfilmentCode("ABC123")
         .language("eng")
@@ -749,7 +766,12 @@ public class CaseServiceImplTest {
   }
 
   private void doVerifyFulfilmentRequestByPostFailsValidation(
-      List<Product.CaseType> caseTypes, String title, String forename, String surname, boolean individual) throws Exception {
+      List<Product.CaseType> caseTypes,
+      String title,
+      String forename,
+      String surname,
+      boolean individual)
+      throws Exception {
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService =
         FixtureHelper.loadClassFixtures(CaseContainerDTO[].class).get(0);
@@ -765,7 +787,8 @@ public class CaseServiceImplTest {
             Product.DeliveryChannel.POST);
 
     // The mocked productReference will return this product
-    Product productFoundFixture = getProductFoundFixture(caseTypes, Product.DeliveryChannel.POST, individual);
+    Product productFoundFixture =
+        getProductFoundFixture(caseTypes, Product.DeliveryChannel.POST, individual);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -779,7 +802,12 @@ public class CaseServiceImplTest {
   }
 
   private void doFulfilmentRequestByPostSuccess(
-      List<Product.CaseType> caseTypes, String title, String forename, String surname, boolean individual) throws Exception {
+      List<Product.CaseType> caseTypes,
+      String title,
+      String forename,
+      String surname,
+      boolean individual)
+      throws Exception {
     Mockito.clearInvocations(publisher);
 
     // Build results to be returned from search
@@ -797,7 +825,8 @@ public class CaseServiceImplTest {
             Product.DeliveryChannel.POST);
 
     // The mocked productReference will return this product
-    Product productFoundFixture = getProductFoundFixture(caseTypes, Product.DeliveryChannel.POST, individual);
+    Product productFoundFixture =
+        getProductFoundFixture(caseTypes, Product.DeliveryChannel.POST, individual);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -847,7 +876,8 @@ public class CaseServiceImplTest {
     assertEquals(null, actualContact.getTelNo());
   }
 
-  private void doFulfilmentRequestBySMSSuccess(List<Product.CaseType> caseTypes, boolean individual) throws Exception {
+  private void doFulfilmentRequestBySMSSuccess(List<Product.CaseType> caseTypes, boolean individual)
+      throws Exception {
 
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService =
@@ -863,7 +893,8 @@ public class CaseServiceImplTest {
             Product.DeliveryChannel.SMS);
 
     // The mocked productReference will return this product
-    Product productFoundFixture = getProductFoundFixture(caseTypes, Product.DeliveryChannel.SMS, individual);
+    Product productFoundFixture =
+        getProductFoundFixture(caseTypes, Product.DeliveryChannel.SMS, individual);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -115,52 +115,40 @@ public class CaseServiceImplTest {
     // All of the following fail validation because one of the contact detail fields is always null
     // or empty
     doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.HH), null, "John", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.HH), "", "John", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.HH), "Mr", null, "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.HH), "Mr", "", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.HH), "Mr", "John", null, true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.HH), "Mr", "John", "", true);
+        Product.CaseType.HH, null, "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "", "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", null, "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", "", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", "John", null, true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", "John", "", true);
 
     doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.CE), null, "John", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.CE), "", "John", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.CE), "Mr", null, "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.CE), "Mr", "", "Smith", true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.CE), "Mr", "John", null, true);
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Arrays.asList(Product.CaseType.CE), "Mr", "John", "", true);
+        Product.CaseType.CE, null, "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "", "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "Mr", null, "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "Mr", "", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "Mr", "John", null, true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "Mr", "John", "", true);
   }
 
   @Test
   public void testFulfilmentRequestByPost_nonIndividualAllowsNullContactDetails() throws Exception {
     // Test that non-individual cases allow null/empty contact details
-    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.HH), null, null, null, false);
-    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.HH), "", "", "", false);
+    doFulfilmentRequestByPostSuccess(Product.CaseType.HH, null, null, null, false);
+    doFulfilmentRequestByPostSuccess(Product.CaseType.HH, "", "", "", false);
 
-    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.CE), null, null, null, false);
-    doFulfilmentRequestByPostSuccess(Arrays.asList(Product.CaseType.CE), "", "", "", false);
+    doFulfilmentRequestByPostSuccess(Product.CaseType.CE, null, null, null, false);
+    doFulfilmentRequestByPostSuccess(Product.CaseType.CE, "", "", "", false);
   }
 
   @Test
   public void testFulfilmentRequestByPostSuccess_withCaseTypeHH() throws Exception {
-    doFulfilmentRequestByPostSuccess(
-        Arrays.asList(Product.CaseType.HH), "Mr", "Mickey", "Mouse", false);
+    doFulfilmentRequestByPostSuccess(Product.CaseType.HH, "Mr", "Mickey", "Mouse", false);
   }
 
   @Test
   public void testFulfilmentRequestByPostSuccess_withIndividualTrue() throws Exception {
-    doFulfilmentRequestByPostSuccess(
-        Arrays.asList(Product.CaseType.HH), "Mr", "Mickey", "Mouse", true);
+    doFulfilmentRequestByPostSuccess(Product.CaseType.HH, "Mr", "Mickey", "Mouse", true);
   }
 
   @Test
@@ -192,12 +180,12 @@ public class CaseServiceImplTest {
 
   @Test
   public void testFulfilmentRequestBySMSSuccess_withCaseTypeHH() throws Exception {
-    doFulfilmentRequestBySMSSuccess(Arrays.asList(Product.CaseType.HH), false);
+    doFulfilmentRequestBySMSSuccess(Product.CaseType.HH, false);
   }
 
   @Test
   public void testFulfilmentRequestBySMSSuccess_withIndividualTrue() throws Exception {
-    doFulfilmentRequestBySMSSuccess(Arrays.asList(Product.CaseType.HH), true);
+    doFulfilmentRequestBySMSSuccess(Product.CaseType.HH, true);
   }
 
   @Test
@@ -572,15 +560,6 @@ public class CaseServiceImplTest {
     assertEquals("Description of refusal", refusal.getReport());
     assertNull(refusal.getAgentId());
     assertEquals(expectedEventCaseId, refusal.getCollectionCase().getId());
-    // Validate contact details
-    // --- Start of code commented out for 2019 rehearsal. CR-416. ---
-    // Contact actualContact = refusal.getContact();
-    // assertEquals("Mr", actualContact.getTitle());
-    // assertEquals("Steve", actualContact.getForename());
-    // assertEquals("Jones", actualContact.getSurname());
-    // assertNull(actualContact.getEmail());
-    // assertEquals("+447890000000", actualContact.getTelNo());
-    // --- End of code commented out for 2019 rehearsal. CR-416. ---
     // Validate address
     AddressCompact address = refusal.getAddress();
     assertEquals("1 High Street", address.getAddressLine1());
@@ -770,11 +749,7 @@ public class CaseServiceImplTest {
   }
 
   private void doVerifyFulfilmentRequestByPostFailsValidation(
-      List<Product.CaseType> caseTypes,
-      String title,
-      String forename,
-      String surname,
-      boolean individual)
+      Product.CaseType caseType, String title, String forename, String surname, boolean individual)
       throws Exception {
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService =
@@ -792,7 +767,7 @@ public class CaseServiceImplTest {
 
     // The mocked productReference will return this product
     Product productFoundFixture =
-        getProductFoundFixture(caseTypes, Product.DeliveryChannel.POST, individual);
+        getProductFoundFixture(Arrays.asList(caseType), Product.DeliveryChannel.POST, individual);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -806,11 +781,7 @@ public class CaseServiceImplTest {
   }
 
   private void doFulfilmentRequestByPostSuccess(
-      List<Product.CaseType> caseTypes,
-      String title,
-      String forename,
-      String surname,
-      boolean individual)
+      Product.CaseType caseType, String title, String forename, String surname, boolean individual)
       throws Exception {
     Mockito.clearInvocations(publisher);
 
@@ -830,7 +801,7 @@ public class CaseServiceImplTest {
 
     // The mocked productReference will return this product
     Product productFoundFixture =
-        getProductFoundFixture(caseTypes, Product.DeliveryChannel.POST, individual);
+        getProductFoundFixture(Arrays.asList(caseType), Product.DeliveryChannel.POST, individual);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -865,8 +836,7 @@ public class CaseServiceImplTest {
         requestBodyDTOFixture.getFulfilmentCode(), actualFulfilmentRequest.getFulfilmentCode());
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), actualFulfilmentRequest.getCaseId());
 
-    // If the caseType is HI then the individualCaseId should be set, otherwise it should be empty.
-    if (individual) {
+    if (caseType == Product.CaseType.HH && individual) {
       assertNotNull(actualFulfilmentRequest.getIndividualCaseId());
     } else {
       assertEquals(null, actualFulfilmentRequest.getIndividualCaseId());
@@ -880,7 +850,7 @@ public class CaseServiceImplTest {
     assertEquals(null, actualContact.getTelNo());
   }
 
-  private void doFulfilmentRequestBySMSSuccess(List<Product.CaseType> caseTypes, boolean individual)
+  private void doFulfilmentRequestBySMSSuccess(Product.CaseType caseType, boolean individual)
       throws Exception {
 
     // Build results to be returned from search
@@ -898,7 +868,7 @@ public class CaseServiceImplTest {
 
     // The mocked productReference will return this product
     Product productFoundFixture =
-        getProductFoundFixture(caseTypes, Product.DeliveryChannel.SMS, individual);
+        getProductFoundFixture(Arrays.asList(caseType), Product.DeliveryChannel.SMS, individual);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -933,8 +903,7 @@ public class CaseServiceImplTest {
         requestBodyDTOFixture.getFulfilmentCode(), actualFulfilmentRequest.getFulfilmentCode());
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), actualFulfilmentRequest.getCaseId());
 
-    // If the caseType is HI then the individualCaseId should be set, otherwise it should be empty.
-    if (individual) {
+    if (caseType == Product.CaseType.HH && individual) {
       assertNotNull(actualFulfilmentRequest.getIndividualCaseId());
     } else {
       assertEquals(null, actualFulfilmentRequest.getIndividualCaseId());

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
@@ -42,7 +42,7 @@ public class FulfilmentServiceImplTest {
     // The mocked productReference will return this product
     Product returnedProduct =
         Product.builder()
-            .caseType(Product.CaseType.HH)
+            .caseTypes(new ArrayList<Product.CaseType>(List.of(Product.CaseType.HH)))
             .description("foobar")
             .fulfilmentCode("ABC123")
             .language("eng")
@@ -61,7 +61,7 @@ public class FulfilmentServiceImplTest {
     // fulfilmentService should call the productReference with this example Product
     Product expectedExample =
         Product.builder()
-            .caseType(Product.CaseType.HH)
+            .caseTypes(new ArrayList<Product.CaseType>(List.of(Product.CaseType.HH)))
             .regions(new ArrayList<Product.Region>(List.of(Product.Region.E)))
             .requestChannels(
                 new ArrayList<Product.RequestChannel>(List.of(Product.RequestChannel.CC)))
@@ -78,7 +78,7 @@ public class FulfilmentServiceImplTest {
     assertTrue(fulfilments.size() == 1);
     FulfilmentDTO fulfilment = fulfilments.get(0);
 
-    assertEquals(fulfilment.getCaseType().name(), CaseType.HH.name());
+    assertEquals(fulfilment.getCaseTypes().get(0).name(), CaseType.HH.name());
     assertEquals(fulfilment.getDescription(), "foobar");
     assertEquals(
         fulfilment.getDeliveryChannel().name(),

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
@@ -58,7 +58,7 @@ public class FulfilmentServiceImplTest {
 
     // call the unit under test
     List<FulfilmentDTO> fulfilments =
-        fulfilmentService.getFulfilments(CaseType.HH, Region.E, DeliveryChannel.POST);
+        fulfilmentService.getFulfilments(CaseType.HH, Region.E, DeliveryChannel.POST, false);
 
     // fulfilmentService should call the productReference with this example Product
     Product expectedExample =
@@ -68,6 +68,7 @@ public class FulfilmentServiceImplTest {
             .requestChannels(
                 new ArrayList<Product.RequestChannel>(List.of(Product.RequestChannel.CC)))
             .deliveryChannel(Product.DeliveryChannel.POST)
+            .individual(false)
             .build();
 
     // verify that the unit under test called the expected productReference and with the
@@ -101,7 +102,7 @@ public class FulfilmentServiceImplTest {
 
     // call the unit under test
     List<FulfilmentDTO> fulfilments =
-        fulfilmentService.getFulfilments(CaseType.HH, Region.E, DeliveryChannel.POST);
+        fulfilmentService.getFulfilments(CaseType.HH, Region.E, DeliveryChannel.POST, false);
 
     // now check that no dtos were returned
     assertTrue(fulfilments.size() == 0);

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
@@ -20,6 +20,7 @@ import uk.gov.ons.ctp.integration.common.product.ProductReference;
 import uk.gov.ons.ctp.integration.common.product.model.Product;
 import uk.gov.ons.ctp.integration.contactcentresvc.CCSvcBeanMapper;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseType;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.FulfilmentDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.FulfilmentsService;
@@ -56,7 +57,8 @@ public class FulfilmentServiceImplTest {
         .thenReturn(new ArrayList<Product>(List.of(returnedProduct)));
 
     // call the unit under test
-    List<FulfilmentDTO> fulfilments = fulfilmentService.getFulfilments(CaseType.HH, Region.E);
+    List<FulfilmentDTO> fulfilments =
+        fulfilmentService.getFulfilments(CaseType.HH, Region.E, DeliveryChannel.POST);
 
     // fulfilmentService should call the productReference with this example Product
     Product expectedExample =
@@ -97,7 +99,8 @@ public class FulfilmentServiceImplTest {
     Mockito.when(productReference.searchProducts(any())).thenReturn(new ArrayList<Product>());
 
     // call the unit under test
-    List<FulfilmentDTO> fulfilments = fulfilmentService.getFulfilments(CaseType.HH, Region.E);
+    List<FulfilmentDTO> fulfilments =
+        fulfilmentService.getFulfilments(CaseType.HH, Region.E, DeliveryChannel.POST);
 
     // now check that no dtos were returned
     assertTrue(fulfilments.size() == 0);

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
@@ -67,6 +67,7 @@ public class FulfilmentServiceImplTest {
             .regions(new ArrayList<Product.Region>(List.of(Product.Region.E)))
             .requestChannels(
                 new ArrayList<Product.RequestChannel>(List.of(Product.RequestChannel.CC)))
+            .deliveryChannel(Product.DeliveryChannel.POST)
             .build();
 
     // verify that the unit under test called the expected productReference and with the

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/FulfilmentServiceImplTest.java
@@ -22,6 +22,7 @@ import uk.gov.ons.ctp.integration.contactcentresvc.CCSvcBeanMapper;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseType;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.FulfilmentDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.ProductGroup;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.FulfilmentsService;
 
@@ -58,7 +59,8 @@ public class FulfilmentServiceImplTest {
 
     // call the unit under test
     List<FulfilmentDTO> fulfilments =
-        fulfilmentService.getFulfilments(CaseType.HH, Region.E, DeliveryChannel.POST, false);
+        fulfilmentService.getFulfilments(
+            CaseType.HH, Region.E, DeliveryChannel.POST, false, ProductGroup.LARGE_PRINT);
 
     // fulfilmentService should call the productReference with this example Product
     Product expectedExample =
@@ -69,6 +71,7 @@ public class FulfilmentServiceImplTest {
                 new ArrayList<Product.RequestChannel>(List.of(Product.RequestChannel.CC)))
             .deliveryChannel(Product.DeliveryChannel.POST)
             .individual(false)
+            .productGroup(Product.ProductGroup.LARGE_PRINT)
             .build();
 
     // verify that the unit under test called the expected productReference and with the
@@ -102,7 +105,8 @@ public class FulfilmentServiceImplTest {
 
     // call the unit under test
     List<FulfilmentDTO> fulfilments =
-        fulfilmentService.getFulfilments(CaseType.HH, Region.E, DeliveryChannel.POST, false);
+        fulfilmentService.getFulfilments(
+            CaseType.HH, Region.E, DeliveryChannel.POST, false, ProductGroup.LARGE_PRINT);
 
     // now check that no dtos were returned
     assertTrue(fulfilments.size() == 0);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This  change is required to allow the contact centre service to use the latest version (1.0.1) of the product reference library and to meet the following requirements from card CR-737:

The GET /fulfilments endpoint currently allows the result list to be filtered by optional request params for caseType and region.

See swagger spec in GH census-contact-centre-service-api/swagger.yml

We need to additionally support filtering by the same method, by :

productGroup
individual (true|false)
(singular) deliveryChannel (SMS|POST)
Valid productGroups can be seen in the CC swagger spec, and in the census-int-product-reference v1.0.1

This will need to use the 1.0.1 version of the product reference library, refactored to allow for individual (true|false) and multiple case types

Also ensure that the endpoint only accepts case types HH|SPG|CE - anything else should error back to Serco

Be aware that the individual flag should only be set in the example Product used in the search if explicitly set by Serco ie there should be no default.
When not provided by Serco, we should not include a default in the search - by not setting the individual flag in the example, we are effectively being individual agnostic and will get back both individual and non-individual products, which is correct.

# How to test?
<!--- Describe in detail how you tested your changes. -->
Test the changes by running all the census-contact-centre-cucumber features (in branch CR-737 of the census-contact-centre-cucumber repo). To do this the following services need to be running:-

- rabbit mq
- contact-centre-service 
- census-mock-case-api-service

Once these are running then you can run all the features using this command:

mvn test