### PR TITLE
Cr 748

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.66</version>
+      <version>0.0.67-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -149,7 +149,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-case-api-client</artifactId>
-      <version>0.0.9</version>
+      <version>0.0.10</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.67-SNAPSHOT</version>
+      <version>0.0.68</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
 import static uk.gov.ons.ctp.integration.contactcentresvc.utility.Constants.UNKNOWN_UUID;
-
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
@@ -23,6 +22,7 @@ import uk.gov.ons.ctp.common.event.EventPublisher;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.EventPublisher.Source;
+import uk.gov.ons.ctp.common.event.model.Address;
 import uk.gov.ons.ctp.common.event.model.AddressCompact;
 import uk.gov.ons.ctp.common.event.model.CollectionCaseCompact;
 import uk.gov.ons.ctp.common.event.model.Contact;
@@ -58,22 +58,28 @@ import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchService;
 @Configuration
 public class CaseServiceImpl implements CaseService {
 
-  @Autowired private EventPublisher publisher;
+  @Autowired
+  private EventPublisher publisher;
 
   private static final Logger log = LoggerFactory.getLogger(CaseServiceImpl.class);
   private static final String RESPONDENT_REFUSAL_TYPE = "HARD_REFUSAL";
 
-  @Autowired private AppConfig appConfig;
+  @Autowired
+  private AppConfig appConfig;
 
-  @Autowired private CaseServiceClientServiceImpl caseServiceClient;
+  @Autowired
+  private CaseServiceClientServiceImpl caseServiceClient;
 
-  @Autowired private ProductReference productReference;
+  @Autowired
+  private ProductReference productReference;
 
   private MapperFacade caseDTOMapper = new CCSvcBeanMapper();
 
-  @Autowired private EqLaunchService eqLaunchService;
+  @Autowired
+  private EqLaunchService eqLaunchService;
 
-  @Autowired private EventPublisher eventPublisher;
+  @Autowired
+  private EventPublisher eventPublisher;
 
   public ResponseDTO fulfilmentRequestByPost(PostalFulfilmentRequestDTO requestBodyDTO)
       throws CTPException {
@@ -88,14 +94,10 @@ public class CaseServiceImpl implements CaseService {
     contact.setForename(requestBodyDTO.getForename());
     contact.setSurname(requestBodyDTO.getSurname());
 
-    FulfilmentRequest fulfilmentRequestPayload =
-        createFulfilmentRequestPayload(
-            requestBodyDTO.getFulfilmentCode(), Product.DeliveryChannel.POST, caseId, contact);
+    FulfilmentRequest fulfilmentRequestPayload = createFulfilmentRequestPayload(
+        requestBodyDTO.getFulfilmentCode(), Product.DeliveryChannel.POST, caseId, contact);
 
-    publisher.sendEvent(
-        EventType.FULFILMENT_REQUESTED,
-        Source.CONTACT_CENTRE_API,
-        Channel.CC,
+    publisher.sendEvent(EventType.FULFILMENT_REQUESTED, Source.CONTACT_CENTRE_API, Channel.CC,
         fulfilmentRequestPayload);
 
     ResponseDTO response =
@@ -117,13 +119,9 @@ public class CaseServiceImpl implements CaseService {
     Contact contact = new Contact();
     contact.setTelNo(requestBodyDTO.getTelNo());
 
-    FulfilmentRequest fulfilmentRequestedPayload =
-        createFulfilmentRequestPayload(
-            requestBodyDTO.getFulfilmentCode(), Product.DeliveryChannel.SMS, caseId, contact);
-    publisher.sendEvent(
-        EventType.FULFILMENT_REQUESTED,
-        Source.CONTACT_CENTRE_API,
-        Channel.CC,
+    FulfilmentRequest fulfilmentRequestedPayload = createFulfilmentRequestPayload(
+        requestBodyDTO.getFulfilmentCode(), Product.DeliveryChannel.SMS, caseId, contact);
+    publisher.sendEvent(EventType.FULFILMENT_REQUESTED, Source.CONTACT_CENTRE_API, Channel.CC,
         fulfilmentRequestedPayload);
 
     ResponseDTO response =
@@ -162,8 +160,8 @@ public class CaseServiceImpl implements CaseService {
 
   private CaseDTO mapCaseContainerDTO(CaseContainerDTO caseDetails) {
     CaseDTO caseServiceResponse = caseDTOMapper.map(caseDetails, CaseDTO.class);
-    caseServiceResponse.setAllowedDeliveryChannels(
-        calculateAllowedDeliveryChannels(caseServiceResponse));
+    caseServiceResponse
+        .setAllowedDeliveryChannels(calculateAllowedDeliveryChannels(caseServiceResponse));
 
     return caseServiceResponse;
   }
@@ -172,8 +170,8 @@ public class CaseServiceImpl implements CaseService {
     List<CaseDTO> caseServiceListResponse = caseDTOMapper.mapAsList(casesToReturn, CaseDTO.class);
 
     for (CaseDTO caseServiceResponse : caseServiceListResponse) {
-      caseServiceResponse.setAllowedDeliveryChannels(
-          calculateAllowedDeliveryChannels(caseServiceResponse));
+      caseServiceResponse
+          .setAllowedDeliveryChannels(calculateAllowedDeliveryChannels(caseServiceResponse));
     }
 
     return caseServiceListResponse;
@@ -186,9 +184,8 @@ public class CaseServiceImpl implements CaseService {
     if (caseServiceResponse.isHandDelivery()
         && caseServiceResponse.getCaseType().equals(CaseType.SPG.name())) {
       log.with(caseServiceResponse.getId())
-          .debug(
-              "Calculating allowed delivery channel list as [SMS] because handDelivery=true "
-                  + "and caseType=SPG");
+          .debug("Calculating allowed delivery channel list as [SMS] because handDelivery=true "
+              + "and caseType=SPG");
       dcList = Arrays.asList(DeliveryChannel.SMS);
     } else {
       log.with(caseServiceResponse.getId())
@@ -200,8 +197,8 @@ public class CaseServiceImpl implements CaseService {
   }
 
   @Override
-  public List<CaseDTO> getCaseByUPRN(
-      UniquePropertyReferenceNumber uprn, CaseRequestDTO requestParamsDTO) {
+  public List<CaseDTO> getCaseByUPRN(UniquePropertyReferenceNumber uprn,
+      CaseRequestDTO requestParamsDTO) {
     log.with("uprn", uprn).debug("Fetching case details by UPRN");
 
     // Get the case details from the case service
@@ -210,12 +207,8 @@ public class CaseServiceImpl implements CaseService {
         caseServiceClient.getCaseByUprn(uprn.getValue(), getCaseEvents);
 
     // Only return cases that are not of caseType = HI
-    List<CaseContainerDTO> casesToReturn =
-        (List<CaseContainerDTO>)
-            caseDetails
-                .parallelStream()
-                .filter(c -> !(c.getCaseType().equals(CaseType.HI.name())))
-                .collect(Collectors.toList());
+    List<CaseContainerDTO> casesToReturn = (List<CaseContainerDTO>) caseDetails.parallelStream()
+        .filter(c -> !(c.getCaseType().equals(CaseType.HI.name()))).collect(Collectors.toList());
 
     // Convert from Case service to Contact Centre DTOs
     List<CaseDTO> caseServiceResponse = mapCaseContainerDTOList(casesToReturn);
@@ -223,8 +216,7 @@ public class CaseServiceImpl implements CaseService {
     // Clean up the events before returning them
     caseServiceResponse.stream().forEach(c -> filterCaseEvents(c, getCaseEvents));
 
-    log.with("uprn", uprn)
-        .with("cases", caseServiceResponse.size())
+    log.with("uprn", uprn).with("cases", caseServiceResponse.size())
         .debug("Returning case details for UPRN");
 
     return caseServiceResponse;
@@ -261,8 +253,7 @@ public class CaseServiceImpl implements CaseService {
     if (requestBodyDTO.getDateTime() != null) {
       reportedDateTime = DateTimeUtil.formatDate(requestBodyDTO.getDateTime());
     }
-    log.with("caseId", caseId)
-        .with("reportedDateTime", reportedDateTime)
+    log.with("caseId", caseId).with("reportedDateTime", reportedDateTime)
         .debug("Processing refusal for case with reported dateTime");
 
     // Create and publish a respondent refusal event
@@ -270,15 +261,13 @@ public class CaseServiceImpl implements CaseService {
     RespondentRefusalDetails refusalPayload =
         createRespondentRefusalPayload(refusalCaseId, requestBodyDTO);
 
-    publisher.sendEvent(
-        EventType.REFUSAL_RECEIVED, Source.CONTACT_CENTRE_API, Channel.CC, refusalPayload);
+    publisher.sendEvent(EventType.REFUSAL_RECEIVED, Source.CONTACT_CENTRE_API, Channel.CC,
+        refusalPayload);
 
     // Build response
     ResponseDTO response =
-        ResponseDTO.builder()
-            .id(caseId == null ? UNKNOWN_UUID : caseId.toString())
-            .dateTime(DateTimeUtil.nowUTC())
-            .build();
+        ResponseDTO.builder().id(caseId == null ? UNKNOWN_UUID : caseId.toString())
+            .dateTime(DateTimeUtil.nowUTC()).build();
 
     log.with("caseId", caseId).debug("Returning refusal response for case");
 
@@ -288,8 +277,7 @@ public class CaseServiceImpl implements CaseService {
   @Override
   public String getLaunchURLForCaseId(final UUID caseId, LaunchRequestDTO requestParamsDTO)
       throws CTPException {
-    log.with("caseId", caseId)
-        .with("request", requestParamsDTO)
+    log.with("caseId", caseId).with("request", requestParamsDTO)
         .debug("Processing request to create launch URL");
 
     // Validate case known and is for CE or HH
@@ -315,25 +303,16 @@ public class CaseServiceImpl implements CaseService {
         caseServiceClient.getSingleUseQuestionnaireId(caseId, individual, individualCaseId);
     String questionnaireId = newQuestionnaireIdDto.getQuestionnaireId();
     String formType = newQuestionnaireIdDto.getFormType();
-    log.with("newQuestionnaireID", questionnaireId)
-        .with("formType", formType)
+    log.with("newQuestionnaireID", questionnaireId).with("formType", formType)
         .info("Have generated new questionnaireId");
 
     // Finally, build the url needed to launch the survey
     String encryptedPayload = "";
     try {
-      encryptedPayload =
-          eqLaunchService.getEqLaunchJwe(
-              Language.ENGLISH,
-              uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API,
-              uk.gov.ons.ctp.common.model.Channel.CC,
-              caseDetails,
-              requestParamsDTO.getAgentId(),
-              questionnaireId,
-              formType,
-              null,
-              null,
-              appConfig.getKeystore());
+      encryptedPayload = eqLaunchService.getEqLaunchJwe(Language.ENGLISH,
+          uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API,
+          uk.gov.ons.ctp.common.model.Channel.CC, caseDetails, requestParamsDTO.getAgentId(),
+          questionnaireId, formType, null, null, appConfig.getKeystore());
     } catch (CTPException e) {
       log.with(e).error("Failed to create JWE payload for eq launch");
       throw e;
@@ -350,24 +329,16 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private void publishSurveyLaunchedEvent(UUID caseId, String questionnaireId, String agentId) {
-    log.with("questionnaireId", questionnaireId)
-        .with("caseId", caseId)
-        .with("agentId", agentId)
+    log.with("questionnaireId", questionnaireId).with("caseId", caseId).with("agentId", agentId)
         .info("Generating SurveyLaunched event");
 
-    SurveyLaunchedResponse response =
-        SurveyLaunchedResponse.builder()
-            .questionnaireId(questionnaireId)
-            .caseId(caseId)
-            .agentId(agentId)
-            .build();
+    SurveyLaunchedResponse response = SurveyLaunchedResponse.builder()
+        .questionnaireId(questionnaireId).caseId(caseId).agentId(agentId).build();
 
-    String transactionId =
-        eventPublisher.sendEvent(
-            EventType.SURVEY_LAUNCHED, Source.CONTACT_CENTRE_API, Channel.CC, response);
+    String transactionId = eventPublisher.sendEvent(EventType.SURVEY_LAUNCHED,
+        Source.CONTACT_CENTRE_API, Channel.CC, response);
 
-    log.with("caseId", response.getCaseId())
-        .with("transactionId", transactionId)
+    log.with("caseId", response.getCaseId()).with("transactionId", transactionId)
         .debug("SurveyLaunch event published");
   }
 
@@ -376,12 +347,9 @@ public class CaseServiceImpl implements CaseService {
       // Only return whitelisted events
       Set<String> whitelistedEventCategories =
           appConfig.getCaseServiceSettings().getWhitelistedEventCategories();
-      List<CaseEventDTO> filteredEvents =
-          caseDTO
-              .getCaseEvents()
-              .stream()
-              .filter(e -> whitelistedEventCategories.contains(e.getCategory()))
-              .collect(Collectors.toList());
+      List<CaseEventDTO> filteredEvents = caseDTO.getCaseEvents().stream()
+          .filter(e -> whitelistedEventCategories.contains(e.getCategory()))
+          .collect(Collectors.toList());
       caseDTO.setCaseEvents(filteredEvents);
     } else {
       // Caller doesn't want any event data
@@ -398,9 +366,8 @@ public class CaseServiceImpl implements CaseService {
    * @return the request event to be delivered to the events exchange
    * @throws CTPException the requested product is invalid for the parameters given
    */
-  private FulfilmentRequest createFulfilmentRequestPayload(
-      String fulfilmentCode, Product.DeliveryChannel deliveryChannel, UUID caseId, Contact contact)
-      throws CTPException {
+  private FulfilmentRequest createFulfilmentRequestPayload(String fulfilmentCode,
+      Product.DeliveryChannel deliveryChannel, UUID caseId, Contact contact) throws CTPException {
     log.with(fulfilmentCode)
         .debug("Entering createFulfilmentEvent method in class CaseServiceImpl");
 
@@ -411,17 +378,15 @@ public class CaseServiceImpl implements CaseService {
     if (deliveryChannel == Product.DeliveryChannel.POST) {
       if (caze.isHandDelivery()) {
         log.info("Postal fulfilments cannot be delivered to this respondent");
-        throw new CTPException(
-            Fault.BAD_REQUEST, "Postal fulfilments cannot be delivered to this respondent");
+        throw new CTPException(Fault.BAD_REQUEST,
+            "Postal fulfilments cannot be delivered to this respondent");
       }
       if (product.getIndividual()) {
-        if (StringUtils.isBlank(contact.getTitle())
-            || StringUtils.isBlank(contact.getForename())
+        if (StringUtils.isBlank(contact.getTitle()) || StringUtils.isBlank(contact.getForename())
             || StringUtils.isBlank(contact.getSurname())) {
 
           log.warn("Individual fields are required for the requested fulfilment");
-          throw new CTPException(
-              Fault.BAD_REQUEST,
+          throw new CTPException(Fault.BAD_REQUEST,
               "The fulfilment is for an individual so none of the following fields can be empty: "
                   + "'title', 'forename' and 'surname'");
         }
@@ -440,6 +405,24 @@ public class CaseServiceImpl implements CaseService {
     fulfilmentRequest.setCaseId(caseId.toString());
     fulfilmentRequest.setContact(contact);
 
+    // Get the case address details from the case service
+    CaseContainerDTO caseDetails = caseServiceClient.getCaseById(caseId, false);
+    Address address = new Address();
+    address.setAddressLine1(caseDetails.getAddressLine1());
+    address.setAddressLine2(caseDetails.getAddressLine2());
+    address.setAddressLine3(caseDetails.getAddressLine3());
+    address.setTownName(caseDetails.getTownName());
+    address.setPostcode(caseDetails.getPostcode());
+    address.setRegion(caseDetails.getRegion());
+    address.setLatitude(caseDetails.getLatitude());
+    address.setLongitude(caseDetails.getLongitude());
+    address.setUprn(caseDetails.getUprn());
+    address.setArid(caseDetails.getArid());
+    // address.setAddressType(caseDetails.); - the addressType field does not currently exist in
+    // CaseContainerDTO
+    address.setEstabType(caseDetails.getEstabType());
+    fulfilmentRequest.setAddress(address);
+
     return fulfilmentRequest;
   }
 
@@ -449,24 +432,17 @@ public class CaseServiceImpl implements CaseService {
    * @param fulfilmentCode the code for the product requested
    * @param deliveryChannel how should the fulfilment be delivered
    * @param region identifies the region of the household case the fulfilment is for - used to
-   *     confirm the requested products eligibility
+   *        confirm the requested products eligibility
    * @return the matching product
    * @throws CTPException the product could not found or is ineligible for the given parameters
    */
-  private Product findProduct(
-      String fulfilmentCode, Product.DeliveryChannel deliveryChannel, Product.Region region)
-      throws CTPException {
-    log.with(fulfilmentCode)
-        .with(deliveryChannel)
-        .with(region)
+  private Product findProduct(String fulfilmentCode, Product.DeliveryChannel deliveryChannel,
+      Product.Region region) throws CTPException {
+    log.with(fulfilmentCode).with(deliveryChannel).with(region)
         .debug("Passing fulfilmentCode, deliveryChannel, and region, into findProduct method.");
-    Product searchCriteria =
-        Product.builder()
-            .fulfilmentCode(fulfilmentCode)
-            .requestChannels(Arrays.asList(Product.RequestChannel.CC))
-            .deliveryChannel(deliveryChannel)
-            .regions(Arrays.asList(region))
-            .build();
+    Product searchCriteria = Product.builder().fulfilmentCode(fulfilmentCode)
+        .requestChannels(Arrays.asList(Product.RequestChannel.CC)).deliveryChannel(deliveryChannel)
+        .regions(Arrays.asList(region)).build();
     List<Product> products = productReference.searchProducts(searchCriteria);
     if (products.size() == 0) {
       log.with("searchCriteria", searchCriteria).warn("Compatible product cannot be found");
@@ -480,13 +456,13 @@ public class CaseServiceImpl implements CaseService {
    * Create a case refusal event.
    *
    * @param caseId is the UUID for the case, or null if the endpoint was invoked with a caseId of
-   *     'unknown'.
+   *        'unknown'.
    * @param refusalRequest holds the details about the refusal.
    * @return the request event to be delivered to the events exchange.
    * @throws CTPException if there is a failure.
    */
-  private RespondentRefusalDetails createRespondentRefusalPayload(
-      UUID caseId, RefusalRequestDTO refusalRequest) throws CTPException {
+  private RespondentRefusalDetails createRespondentRefusalPayload(UUID caseId,
+      RefusalRequestDTO refusalRequest) throws CTPException {
 
     // Create message payload
     RespondentRefusalDetails refusal = new RespondentRefusalDetails();

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -454,8 +454,7 @@ public class CaseServiceImpl implements CaseService {
     address.setLongitude(caseDetails.getLongitude());
     address.setUprn(caseDetails.getUprn());
     address.setArid(caseDetails.getArid());
-    // address.setAddressType(caseDetails.); - the addressType field does not currently exist in
-    // CaseContainerDTO
+    address.setAddressType(caseDetails.getAddressType()); 
     address.setEstabType(caseDetails.getEstabType());
     fulfilmentRequest.setAddress(address);
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -454,7 +454,7 @@ public class CaseServiceImpl implements CaseService {
     address.setLongitude(caseDetails.getLongitude());
     address.setUprn(caseDetails.getUprn());
     address.setArid(caseDetails.getArid());
-    address.setAddressType(caseDetails.getAddressType()); 
+    address.setAddressType(caseDetails.getAddressType());
     address.setEstabType(caseDetails.getEstabType());
     fulfilmentRequest.setAddress(address);
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
 import static uk.gov.ons.ctp.integration.contactcentresvc.utility.Constants.UNKNOWN_UUID;
+
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.util.Arrays;
@@ -58,28 +59,22 @@ import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchService;
 @Configuration
 public class CaseServiceImpl implements CaseService {
 
-  @Autowired
-  private EventPublisher publisher;
+  @Autowired private EventPublisher publisher;
 
   private static final Logger log = LoggerFactory.getLogger(CaseServiceImpl.class);
   private static final String RESPONDENT_REFUSAL_TYPE = "HARD_REFUSAL";
 
-  @Autowired
-  private AppConfig appConfig;
+  @Autowired private AppConfig appConfig;
 
-  @Autowired
-  private CaseServiceClientServiceImpl caseServiceClient;
+  @Autowired private CaseServiceClientServiceImpl caseServiceClient;
 
-  @Autowired
-  private ProductReference productReference;
+  @Autowired private ProductReference productReference;
 
   private MapperFacade caseDTOMapper = new CCSvcBeanMapper();
 
-  @Autowired
-  private EqLaunchService eqLaunchService;
+  @Autowired private EqLaunchService eqLaunchService;
 
-  @Autowired
-  private EventPublisher eventPublisher;
+  @Autowired private EventPublisher eventPublisher;
 
   public ResponseDTO fulfilmentRequestByPost(PostalFulfilmentRequestDTO requestBodyDTO)
       throws CTPException {
@@ -94,10 +89,14 @@ public class CaseServiceImpl implements CaseService {
     contact.setForename(requestBodyDTO.getForename());
     contact.setSurname(requestBodyDTO.getSurname());
 
-    FulfilmentRequest fulfilmentRequestPayload = createFulfilmentRequestPayload(
-        requestBodyDTO.getFulfilmentCode(), Product.DeliveryChannel.POST, caseId, contact);
+    FulfilmentRequest fulfilmentRequestPayload =
+        createFulfilmentRequestPayload(
+            requestBodyDTO.getFulfilmentCode(), Product.DeliveryChannel.POST, caseId, contact);
 
-    publisher.sendEvent(EventType.FULFILMENT_REQUESTED, Source.CONTACT_CENTRE_API, Channel.CC,
+    publisher.sendEvent(
+        EventType.FULFILMENT_REQUESTED,
+        Source.CONTACT_CENTRE_API,
+        Channel.CC,
         fulfilmentRequestPayload);
 
     ResponseDTO response =
@@ -119,9 +118,13 @@ public class CaseServiceImpl implements CaseService {
     Contact contact = new Contact();
     contact.setTelNo(requestBodyDTO.getTelNo());
 
-    FulfilmentRequest fulfilmentRequestedPayload = createFulfilmentRequestPayload(
-        requestBodyDTO.getFulfilmentCode(), Product.DeliveryChannel.SMS, caseId, contact);
-    publisher.sendEvent(EventType.FULFILMENT_REQUESTED, Source.CONTACT_CENTRE_API, Channel.CC,
+    FulfilmentRequest fulfilmentRequestedPayload =
+        createFulfilmentRequestPayload(
+            requestBodyDTO.getFulfilmentCode(), Product.DeliveryChannel.SMS, caseId, contact);
+    publisher.sendEvent(
+        EventType.FULFILMENT_REQUESTED,
+        Source.CONTACT_CENTRE_API,
+        Channel.CC,
         fulfilmentRequestedPayload);
 
     ResponseDTO response =
@@ -160,8 +163,8 @@ public class CaseServiceImpl implements CaseService {
 
   private CaseDTO mapCaseContainerDTO(CaseContainerDTO caseDetails) {
     CaseDTO caseServiceResponse = caseDTOMapper.map(caseDetails, CaseDTO.class);
-    caseServiceResponse
-        .setAllowedDeliveryChannels(calculateAllowedDeliveryChannels(caseServiceResponse));
+    caseServiceResponse.setAllowedDeliveryChannels(
+        calculateAllowedDeliveryChannels(caseServiceResponse));
 
     return caseServiceResponse;
   }
@@ -170,8 +173,8 @@ public class CaseServiceImpl implements CaseService {
     List<CaseDTO> caseServiceListResponse = caseDTOMapper.mapAsList(casesToReturn, CaseDTO.class);
 
     for (CaseDTO caseServiceResponse : caseServiceListResponse) {
-      caseServiceResponse
-          .setAllowedDeliveryChannels(calculateAllowedDeliveryChannels(caseServiceResponse));
+      caseServiceResponse.setAllowedDeliveryChannels(
+          calculateAllowedDeliveryChannels(caseServiceResponse));
     }
 
     return caseServiceListResponse;
@@ -184,8 +187,9 @@ public class CaseServiceImpl implements CaseService {
     if (caseServiceResponse.isHandDelivery()
         && caseServiceResponse.getCaseType().equals(CaseType.SPG.name())) {
       log.with(caseServiceResponse.getId())
-          .debug("Calculating allowed delivery channel list as [SMS] because handDelivery=true "
-              + "and caseType=SPG");
+          .debug(
+              "Calculating allowed delivery channel list as [SMS] because handDelivery=true "
+                  + "and caseType=SPG");
       dcList = Arrays.asList(DeliveryChannel.SMS);
     } else {
       log.with(caseServiceResponse.getId())
@@ -197,8 +201,8 @@ public class CaseServiceImpl implements CaseService {
   }
 
   @Override
-  public List<CaseDTO> getCaseByUPRN(UniquePropertyReferenceNumber uprn,
-      CaseRequestDTO requestParamsDTO) {
+  public List<CaseDTO> getCaseByUPRN(
+      UniquePropertyReferenceNumber uprn, CaseRequestDTO requestParamsDTO) {
     log.with("uprn", uprn).debug("Fetching case details by UPRN");
 
     // Get the case details from the case service
@@ -207,8 +211,12 @@ public class CaseServiceImpl implements CaseService {
         caseServiceClient.getCaseByUprn(uprn.getValue(), getCaseEvents);
 
     // Only return cases that are not of caseType = HI
-    List<CaseContainerDTO> casesToReturn = (List<CaseContainerDTO>) caseDetails.parallelStream()
-        .filter(c -> !(c.getCaseType().equals(CaseType.HI.name()))).collect(Collectors.toList());
+    List<CaseContainerDTO> casesToReturn =
+        (List<CaseContainerDTO>)
+            caseDetails
+                .parallelStream()
+                .filter(c -> !(c.getCaseType().equals(CaseType.HI.name())))
+                .collect(Collectors.toList());
 
     // Convert from Case service to Contact Centre DTOs
     List<CaseDTO> caseServiceResponse = mapCaseContainerDTOList(casesToReturn);
@@ -216,7 +224,8 @@ public class CaseServiceImpl implements CaseService {
     // Clean up the events before returning them
     caseServiceResponse.stream().forEach(c -> filterCaseEvents(c, getCaseEvents));
 
-    log.with("uprn", uprn).with("cases", caseServiceResponse.size())
+    log.with("uprn", uprn)
+        .with("cases", caseServiceResponse.size())
         .debug("Returning case details for UPRN");
 
     return caseServiceResponse;
@@ -253,7 +262,8 @@ public class CaseServiceImpl implements CaseService {
     if (requestBodyDTO.getDateTime() != null) {
       reportedDateTime = DateTimeUtil.formatDate(requestBodyDTO.getDateTime());
     }
-    log.with("caseId", caseId).with("reportedDateTime", reportedDateTime)
+    log.with("caseId", caseId)
+        .with("reportedDateTime", reportedDateTime)
         .debug("Processing refusal for case with reported dateTime");
 
     // Create and publish a respondent refusal event
@@ -261,13 +271,15 @@ public class CaseServiceImpl implements CaseService {
     RespondentRefusalDetails refusalPayload =
         createRespondentRefusalPayload(refusalCaseId, requestBodyDTO);
 
-    publisher.sendEvent(EventType.REFUSAL_RECEIVED, Source.CONTACT_CENTRE_API, Channel.CC,
-        refusalPayload);
+    publisher.sendEvent(
+        EventType.REFUSAL_RECEIVED, Source.CONTACT_CENTRE_API, Channel.CC, refusalPayload);
 
     // Build response
     ResponseDTO response =
-        ResponseDTO.builder().id(caseId == null ? UNKNOWN_UUID : caseId.toString())
-            .dateTime(DateTimeUtil.nowUTC()).build();
+        ResponseDTO.builder()
+            .id(caseId == null ? UNKNOWN_UUID : caseId.toString())
+            .dateTime(DateTimeUtil.nowUTC())
+            .build();
 
     log.with("caseId", caseId).debug("Returning refusal response for case");
 
@@ -277,7 +289,8 @@ public class CaseServiceImpl implements CaseService {
   @Override
   public String getLaunchURLForCaseId(final UUID caseId, LaunchRequestDTO requestParamsDTO)
       throws CTPException {
-    log.with("caseId", caseId).with("request", requestParamsDTO)
+    log.with("caseId", caseId)
+        .with("request", requestParamsDTO)
         .debug("Processing request to create launch URL");
 
     // Validate case known and is for CE or HH
@@ -303,16 +316,25 @@ public class CaseServiceImpl implements CaseService {
         caseServiceClient.getSingleUseQuestionnaireId(caseId, individual, individualCaseId);
     String questionnaireId = newQuestionnaireIdDto.getQuestionnaireId();
     String formType = newQuestionnaireIdDto.getFormType();
-    log.with("newQuestionnaireID", questionnaireId).with("formType", formType)
+    log.with("newQuestionnaireID", questionnaireId)
+        .with("formType", formType)
         .info("Have generated new questionnaireId");
 
     // Finally, build the url needed to launch the survey
     String encryptedPayload = "";
     try {
-      encryptedPayload = eqLaunchService.getEqLaunchJwe(Language.ENGLISH,
-          uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API,
-          uk.gov.ons.ctp.common.model.Channel.CC, caseDetails, requestParamsDTO.getAgentId(),
-          questionnaireId, formType, null, null, appConfig.getKeystore());
+      encryptedPayload =
+          eqLaunchService.getEqLaunchJwe(
+              Language.ENGLISH,
+              uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API,
+              uk.gov.ons.ctp.common.model.Channel.CC,
+              caseDetails,
+              requestParamsDTO.getAgentId(),
+              questionnaireId,
+              formType,
+              null,
+              null,
+              appConfig.getKeystore());
     } catch (CTPException e) {
       log.with(e).error("Failed to create JWE payload for eq launch");
       throw e;
@@ -329,16 +351,24 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private void publishSurveyLaunchedEvent(UUID caseId, String questionnaireId, String agentId) {
-    log.with("questionnaireId", questionnaireId).with("caseId", caseId).with("agentId", agentId)
+    log.with("questionnaireId", questionnaireId)
+        .with("caseId", caseId)
+        .with("agentId", agentId)
         .info("Generating SurveyLaunched event");
 
-    SurveyLaunchedResponse response = SurveyLaunchedResponse.builder()
-        .questionnaireId(questionnaireId).caseId(caseId).agentId(agentId).build();
+    SurveyLaunchedResponse response =
+        SurveyLaunchedResponse.builder()
+            .questionnaireId(questionnaireId)
+            .caseId(caseId)
+            .agentId(agentId)
+            .build();
 
-    String transactionId = eventPublisher.sendEvent(EventType.SURVEY_LAUNCHED,
-        Source.CONTACT_CENTRE_API, Channel.CC, response);
+    String transactionId =
+        eventPublisher.sendEvent(
+            EventType.SURVEY_LAUNCHED, Source.CONTACT_CENTRE_API, Channel.CC, response);
 
-    log.with("caseId", response.getCaseId()).with("transactionId", transactionId)
+    log.with("caseId", response.getCaseId())
+        .with("transactionId", transactionId)
         .debug("SurveyLaunch event published");
   }
 
@@ -347,9 +377,12 @@ public class CaseServiceImpl implements CaseService {
       // Only return whitelisted events
       Set<String> whitelistedEventCategories =
           appConfig.getCaseServiceSettings().getWhitelistedEventCategories();
-      List<CaseEventDTO> filteredEvents = caseDTO.getCaseEvents().stream()
-          .filter(e -> whitelistedEventCategories.contains(e.getCategory()))
-          .collect(Collectors.toList());
+      List<CaseEventDTO> filteredEvents =
+          caseDTO
+              .getCaseEvents()
+              .stream()
+              .filter(e -> whitelistedEventCategories.contains(e.getCategory()))
+              .collect(Collectors.toList());
       caseDTO.setCaseEvents(filteredEvents);
     } else {
       // Caller doesn't want any event data
@@ -366,8 +399,9 @@ public class CaseServiceImpl implements CaseService {
    * @return the request event to be delivered to the events exchange
    * @throws CTPException the requested product is invalid for the parameters given
    */
-  private FulfilmentRequest createFulfilmentRequestPayload(String fulfilmentCode,
-      Product.DeliveryChannel deliveryChannel, UUID caseId, Contact contact) throws CTPException {
+  private FulfilmentRequest createFulfilmentRequestPayload(
+      String fulfilmentCode, Product.DeliveryChannel deliveryChannel, UUID caseId, Contact contact)
+      throws CTPException {
     log.with(fulfilmentCode)
         .debug("Entering createFulfilmentEvent method in class CaseServiceImpl");
 
@@ -378,15 +412,17 @@ public class CaseServiceImpl implements CaseService {
     if (deliveryChannel == Product.DeliveryChannel.POST) {
       if (caze.isHandDelivery()) {
         log.info("Postal fulfilments cannot be delivered to this respondent");
-        throw new CTPException(Fault.BAD_REQUEST,
-            "Postal fulfilments cannot be delivered to this respondent");
+        throw new CTPException(
+            Fault.BAD_REQUEST, "Postal fulfilments cannot be delivered to this respondent");
       }
       if (product.getIndividual()) {
-        if (StringUtils.isBlank(contact.getTitle()) || StringUtils.isBlank(contact.getForename())
+        if (StringUtils.isBlank(contact.getTitle())
+            || StringUtils.isBlank(contact.getForename())
             || StringUtils.isBlank(contact.getSurname())) {
 
           log.warn("Individual fields are required for the requested fulfilment");
-          throw new CTPException(Fault.BAD_REQUEST,
+          throw new CTPException(
+              Fault.BAD_REQUEST,
               "The fulfilment is for an individual so none of the following fields can be empty: "
                   + "'title', 'forename' and 'surname'");
         }
@@ -432,17 +468,24 @@ public class CaseServiceImpl implements CaseService {
    * @param fulfilmentCode the code for the product requested
    * @param deliveryChannel how should the fulfilment be delivered
    * @param region identifies the region of the household case the fulfilment is for - used to
-   *        confirm the requested products eligibility
+   *     confirm the requested products eligibility
    * @return the matching product
    * @throws CTPException the product could not found or is ineligible for the given parameters
    */
-  private Product findProduct(String fulfilmentCode, Product.DeliveryChannel deliveryChannel,
-      Product.Region region) throws CTPException {
-    log.with(fulfilmentCode).with(deliveryChannel).with(region)
+  private Product findProduct(
+      String fulfilmentCode, Product.DeliveryChannel deliveryChannel, Product.Region region)
+      throws CTPException {
+    log.with(fulfilmentCode)
+        .with(deliveryChannel)
+        .with(region)
         .debug("Passing fulfilmentCode, deliveryChannel, and region, into findProduct method.");
-    Product searchCriteria = Product.builder().fulfilmentCode(fulfilmentCode)
-        .requestChannels(Arrays.asList(Product.RequestChannel.CC)).deliveryChannel(deliveryChannel)
-        .regions(Arrays.asList(region)).build();
+    Product searchCriteria =
+        Product.builder()
+            .fulfilmentCode(fulfilmentCode)
+            .requestChannels(Arrays.asList(Product.RequestChannel.CC))
+            .deliveryChannel(deliveryChannel)
+            .regions(Arrays.asList(region))
+            .build();
     List<Product> products = productReference.searchProducts(searchCriteria);
     if (products.size() == 0) {
       log.with("searchCriteria", searchCriteria).warn("Compatible product cannot be found");
@@ -456,13 +499,13 @@ public class CaseServiceImpl implements CaseService {
    * Create a case refusal event.
    *
    * @param caseId is the UUID for the case, or null if the endpoint was invoked with a caseId of
-   *        'unknown'.
+   *     'unknown'.
    * @param refusalRequest holds the details about the refusal.
    * @return the request event to be delivered to the events exchange.
    * @throws CTPException if there is a failure.
    */
-  private RespondentRefusalDetails createRespondentRefusalPayload(UUID caseId,
-      RefusalRequestDTO refusalRequest) throws CTPException {
+  private RespondentRefusalDetails createRespondentRefusalPayload(
+      UUID caseId, RefusalRequestDTO refusalRequest) throws CTPException {
 
     // Create message payload
     RespondentRefusalDetails refusal = new RespondentRefusalDetails();

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -10,6 +10,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -74,29 +75,21 @@ import uk.gov.ons.ctp.integration.eqlaunch.service.impl.EqLaunchServiceImpl;
  * which would deal with actually sending a HTTP request to the case service.
  */
 public class CaseServiceImplTest {
-  @Mock
-  AppConfig appConfig = new AppConfig();
+  @Mock AppConfig appConfig = new AppConfig();
 
-  @Mock
-  ProductReference productReference;
+  @Mock ProductReference productReference;
 
-  @Mock
-  EventPublisher publisher;
+  @Mock EventPublisher publisher;
 
-  @Mock
-  CaseServiceClientServiceImpl caseServiceClient;
+  @Mock CaseServiceClientServiceImpl caseServiceClient;
 
-  @Mock
-  EqLaunchService eqLaunchService = new EqLaunchServiceImpl();
+  @Mock EqLaunchService eqLaunchService = new EqLaunchServiceImpl();
 
-  @Mock
-  EventPublisher eventPublisher;
+  @Mock EventPublisher eventPublisher;
 
-  @Spy
-  private MapperFacade mapperFacade = new CCSvcBeanMapper();
+  @Spy private MapperFacade mapperFacade = new CCSvcBeanMapper();
 
-  @InjectMocks
-  CaseService target = new CaseServiceImpl();
+  @InjectMocks CaseService target = new CaseServiceImpl();
 
   private UUID uuid = UUID.fromString("b7565b5e-1396-4965-91a2-918c0d3642ed");
 
@@ -129,16 +122,16 @@ public class CaseServiceImplTest {
   public void testFulfilmentRequestByPost_individualFailsWithNullContactDetails() throws Exception {
     // All of the following fail validation because one of the contact detail fields is always null
     // or empty
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, null, "John", "Smith",
-        true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Product.CaseType.HH, null, "John", "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "", "John", "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", null, "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", "", "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", "John", null, true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", "John", "", true);
 
-    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, null, "John", "Smith",
-        true);
+    doVerifyFulfilmentRequestByPostFailsValidation(
+        Product.CaseType.CE, null, "John", "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "", "John", "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "Mr", null, "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "Mr", "", "Smith", true);
@@ -176,8 +169,9 @@ public class CaseServiceImplTest {
     PostalFulfilmentRequestDTO requestBodyDTOFixture =
         getPostalFulfilmentRequestDTO(caseData, "Mr", "Mickey", "Mouse");
 
-    Product expectedSearchCriteria = getExpectedSearchCriteria(caseData,
-        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
+    Product expectedSearchCriteria =
+        getExpectedSearchCriteria(
+            caseData, requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
 
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>());
@@ -207,11 +201,15 @@ public class CaseServiceImplTest {
     PostalFulfilmentRequestDTO requestBodyDTOFixture =
         getPostalFulfilmentRequestDTO(caseFromCaseService, "Mrs", "Sally", "Smurf");
 
-    Product expectedSearchCriteria = getExpectedSearchCriteria(caseFromCaseService,
-        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
+    Product expectedSearchCriteria =
+        getExpectedSearchCriteria(
+            caseFromCaseService,
+            requestBodyDTOFixture.getFulfilmentCode(),
+            Product.DeliveryChannel.POST);
 
-    Product productFoundFixture = getProductFoundFixture(Arrays.asList(Product.CaseType.SPG),
-        Product.DeliveryChannel.POST, false);
+    Product productFoundFixture =
+        getProductFoundFixture(
+            Arrays.asList(Product.CaseType.SPG), Product.DeliveryChannel.POST, false);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -244,8 +242,9 @@ public class CaseServiceImplTest {
 
     SMSFulfilmentRequestDTO requestBodyDTOFixture = getSMSFulfilmentRequestDTO(caseData);
 
-    Product expectedSearchCriteria = getExpectedSearchCriteria(caseData,
-        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.SMS);
+    Product expectedSearchCriteria =
+        getExpectedSearchCriteria(
+            caseData, requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.SMS);
 
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>());
@@ -264,55 +263,55 @@ public class CaseServiceImplTest {
   public void testGetHouseholdCaseByCaseId_withCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(
+        CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetHouseholdCaseByCaseId_withNoCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(
+        CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseId_caseHHhandDeliveryTrue() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(CaseType.HH, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(
+        CaseType.HH, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCommunalCaseByCaseId_withCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(CaseType.CE, HAND_DELIVERY_TRUE, CASE_EVENTS_TRUE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(
+        CaseType.CE, HAND_DELIVERY_TRUE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCommunalCaseByCaseId_withNoCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(CaseType.CE, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(
+        CaseType.CE, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseId_caseSPGhandDeliveryTrue() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels = Arrays.asList(DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(CaseType.SPG, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(
+        CaseType.SPG, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseId_caseSPGhandDeliveryFalse() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(CaseType.SPG, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(
+        CaseType.SPG, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
   }
 
   @Test
@@ -377,8 +376,11 @@ public class CaseServiceImplTest {
     List<CaseDTO> results = target.getCaseByUPRN(uprn, new CaseRequestDTO(caseEvents));
     assertEquals(1, results.size());
 
-    CaseDTO expectedCaseResult = createExpectedCaseDTO(caseFromCaseService.get(1), caseEvents,
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+    CaseDTO expectedCaseResult =
+        createExpectedCaseDTO(
+            caseFromCaseService.get(1),
+            caseEvents,
+            Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
     verifyCase(results.get(0), expectedCaseResult, caseEvents);
   }
 
@@ -397,8 +399,9 @@ public class CaseServiceImplTest {
     doTestGetCasesByUprn("SPG", false, Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
   }
 
-  private void doTestGetCasesByUprn(String caseType, boolean handDelivery,
-      List<DeliveryChannel> expectedDeliveryChannels) throws Exception {
+  private void doTestGetCasesByUprn(
+      String caseType, boolean handDelivery, List<DeliveryChannel> expectedDeliveryChannels)
+      throws Exception {
     UniquePropertyReferenceNumber uprn = new UniquePropertyReferenceNumber(334999999999L);
 
     List<CaseContainerDTO> caseFromCaseService =
@@ -422,55 +425,55 @@ public class CaseServiceImplTest {
   public void testGetHouseholdCaseByCaseRef_withCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(
+        CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetHouseholdCaseByCaseRef_withNoCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(
+        CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseRef_caseHHhandDeliveryTrue() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(CaseType.HH, HAND_DELIVERY_TRUE, CASE_EVENTS_TRUE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(
+        CaseType.HH, HAND_DELIVERY_TRUE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCommunalCaseByCaseRef_withCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(CaseType.CE, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(
+        CaseType.CE, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCommunalCaseByCaseRef_withNoCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(CaseType.CE, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(
+        CaseType.CE, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseRef_caseSPGhandDeliveryTrue() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels = Arrays.asList(DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(CaseType.SPG, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(
+        CaseType.SPG, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseRef_caseSPGhandDeliveryFalse() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(CaseType.SPG, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(
+        CaseType.SPG, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
   }
 
   @Test
@@ -582,11 +585,18 @@ public class CaseServiceImplTest {
     Mockito.when(appConfig.getEq()).thenReturn(eqConfig);
 
     // Mock out building of launch payload
-    Mockito
-        .when(eqLaunchService.getEqLaunchJwe(eq(Language.ENGLISH),
-            eq(uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API),
-            eq(uk.gov.ons.ctp.common.model.Channel.CC), any(), any(), any(), any(), any(), any(),
-            isNull())) // keystore
+    Mockito.when(
+            eqLaunchService.getEqLaunchJwe(
+                eq(Language.ENGLISH),
+                eq(uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API),
+                eq(uk.gov.ons.ctp.common.model.Channel.CC),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                isNull())) // keystore
         .thenReturn("simulated-encrypted-payload");
 
     // Build DTO for launch request
@@ -600,8 +610,8 @@ public class CaseServiceImplTest {
 
     // Verify call to RM to get qid is using the correct individual case id
     ArgumentCaptor<UUID> individualCaseIdCaptor = ArgumentCaptor.forClass(UUID.class);
-    Mockito.verify(caseServiceClient).getSingleUseQuestionnaireId(any(), eq(individual),
-        individualCaseIdCaptor.capture());
+    Mockito.verify(caseServiceClient)
+        .getSingleUseQuestionnaireId(any(), eq(individual), individualCaseIdCaptor.capture());
     if (caseType.equals("HH") && individual) {
       assertNotEquals(uuid, individualCaseIdCaptor.getValue()); // expecting newly allocated uuid
     } else {
@@ -610,11 +620,18 @@ public class CaseServiceImplTest {
 
     // Verify correct data passed to eqLauncher
     ArgumentCaptor<CaseContainerDTO> caseCaptor = ArgumentCaptor.forClass(CaseContainerDTO.class);
-    Mockito.verify(eqLaunchService).getEqLaunchJwe(eq(Language.ENGLISH),
-        eq(uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API),
-        eq(uk.gov.ons.ctp.common.model.Channel.CC), caseCaptor.capture(), eq("1234"), // agent
-        eq(questionnaireId), eq(formType), isNull(), // accountServiceUrl
-        isNull(), any()); // keystore
+    Mockito.verify(eqLaunchService)
+        .getEqLaunchJwe(
+            eq(Language.ENGLISH),
+            eq(uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API),
+            eq(uk.gov.ons.ctp.common.model.Channel.CC),
+            caseCaptor.capture(),
+            eq("1234"), // agent
+            eq(questionnaireId),
+            eq(formType),
+            isNull(), // accountServiceUrl
+            isNull(),
+            any()); // keystore
 
     // Verify case details passed to eqLauncher
     CaseContainerDTO capturedCase = caseCaptor.getValue();
@@ -628,9 +645,12 @@ public class CaseServiceImplTest {
     // Verify surveyLaunched event published
     ArgumentCaptor<SurveyLaunchedResponse> surveyLaunchedResponseCaptor =
         ArgumentCaptor.forClass(SurveyLaunchedResponse.class);
-    Mockito.verify(eventPublisher).sendEvent(eq(EventType.SURVEY_LAUNCHED),
-        eq(Source.CONTACT_CENTRE_API), eq(Channel.CC),
-        (EventPayload) surveyLaunchedResponseCaptor.capture());
+    Mockito.verify(eventPublisher)
+        .sendEvent(
+            eq(EventType.SURVEY_LAUNCHED),
+            eq(Source.CONTACT_CENTRE_API),
+            eq(Channel.CC),
+            (EventPayload) surveyLaunchedResponseCaptor.capture());
 
     // Verify payload for surveyLaunched event
     if (caseType.equals("HH") && individual) {
@@ -643,13 +663,25 @@ public class CaseServiceImplTest {
     assertEquals("1234", surveyLaunchedResponseCaptor.getValue().getAgentId());
   }
 
-  private void doRespondentRefusalTest(UUID caseId, UUID expectedEventCaseId,
-      String expectedResponseCaseId, Date dateTime) throws Exception {
-    RefusalRequestDTO refusalPayload = RefusalRequestDTO.builder()
-        .caseId(caseId == null ? null : caseId.toString()).notes("Description of refusal")
-        .title("Mr").forename("Steve").surname("Jones").telNo("+447890000000")
-        .addressLine1("1 High Street").addressLine2("Delph").addressLine3("Oldham")
-        .townName("Manchester").postcode("OL3 5DJ").region("E").dateTime(dateTime).build();
+  private void doRespondentRefusalTest(
+      UUID caseId, UUID expectedEventCaseId, String expectedResponseCaseId, Date dateTime)
+      throws Exception {
+    RefusalRequestDTO refusalPayload =
+        RefusalRequestDTO.builder()
+            .caseId(caseId == null ? null : caseId.toString())
+            .notes("Description of refusal")
+            .title("Mr")
+            .forename("Steve")
+            .surname("Jones")
+            .telNo("+447890000000")
+            .addressLine1("1 High Street")
+            .addressLine2("Delph")
+            .addressLine3("Oldham")
+            .townName("Manchester")
+            .postcode("OL3 5DJ")
+            .region("E")
+            .dateTime(dateTime)
+            .build();
 
     // report the refusal
     long timeBeforeInvocation = System.currentTimeMillis();
@@ -658,8 +690,8 @@ public class CaseServiceImplTest {
 
     // Validate the response to the refusal
     assertEquals(expectedResponseCaseId, refusalResponse.getId());
-    verifyTimeInExpectedRange(timeBeforeInvocation, timeAfterInvocation,
-        refusalResponse.getDateTime());
+    verifyTimeInExpectedRange(
+        timeBeforeInvocation, timeAfterInvocation, refusalResponse.getDateTime());
 
     // Grab the published event
     ArgumentCaptor<EventType> eventTypeCaptor = ArgumentCaptor.forClass(EventType.class);
@@ -667,8 +699,12 @@ public class CaseServiceImplTest {
     ArgumentCaptor<Channel> channelCaptor = ArgumentCaptor.forClass(Channel.class);
     ArgumentCaptor<RespondentRefusalDetails> refusalEventCaptor =
         ArgumentCaptor.forClass(RespondentRefusalDetails.class);
-    verify(publisher).sendEvent(eventTypeCaptor.capture(), sourceCaptor.capture(),
-        channelCaptor.capture(), refusalEventCaptor.capture());
+    verify(publisher)
+        .sendEvent(
+            eventTypeCaptor.capture(),
+            sourceCaptor.capture(),
+            channelCaptor.capture(),
+            refusalEventCaptor.capture());
 
     assertEquals(REFUSAL_EVENT_TYPE_FIELD_VALUE, eventTypeCaptor.getValue());
     assertEquals(REFUSAL_SOURCE_FIELD_VALUE, sourceCaptor.getValue());
@@ -696,8 +732,12 @@ public class CaseServiceImplTest {
     assertTrue(actualInMillis + " not before " + maxAllowed, actualInMillis <= maxAllowed);
   }
 
-  private void doTestGetCaseByCaseId(CaseType caseType, boolean handDelivery, boolean caseEvents,
-      List<DeliveryChannel> expectedAllowedDeliveryChannels) throws Exception {
+  private void doTestGetCaseByCaseId(
+      CaseType caseType,
+      boolean handDelivery,
+      boolean caseEvents,
+      List<DeliveryChannel> expectedAllowedDeliveryChannels)
+      throws Exception {
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService =
         FixtureHelper.loadClassFixtures(CaseContainerDTO[].class).get(0);
@@ -730,17 +770,27 @@ public class CaseServiceImplTest {
     List<CaseDTO> results = target.getCaseByUPRN(uprn, requestParams);
 
     // Verify response
-    CaseDTO expectedCaseResult0 = createExpectedCaseDTO(caseFromCaseService.get(0), caseEvents,
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+    CaseDTO expectedCaseResult0 =
+        createExpectedCaseDTO(
+            caseFromCaseService.get(0),
+            caseEvents,
+            Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
     verifyCase(results.get(0), expectedCaseResult0, caseEvents);
 
-    CaseDTO expectedCaseResult1 = createExpectedCaseDTO(caseFromCaseService.get(1), caseEvents,
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+    CaseDTO expectedCaseResult1 =
+        createExpectedCaseDTO(
+            caseFromCaseService.get(1),
+            caseEvents,
+            Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
     verifyCase(results.get(1), expectedCaseResult1, caseEvents);
   }
 
-  private void doTestGetCaseByCaseRef(CaseType caseType, boolean handDelivery, boolean caseEvents,
-      List<DeliveryChannel> expectedAllowedDeliveryChannels) throws Exception {
+  private void doTestGetCaseByCaseRef(
+      CaseType caseType,
+      boolean handDelivery,
+      boolean caseEvents,
+      List<DeliveryChannel> expectedAllowedDeliveryChannels)
+      throws Exception {
     long testCaseRef = 88234544;
 
     // Build results to be returned from search
@@ -758,28 +808,44 @@ public class CaseServiceImplTest {
     verifyCase(results, expectedCaseResult, caseEvents);
   }
 
-  private CaseDTO createExpectedCaseDTO(CaseContainerDTO caseFromCaseService, boolean caseEvents,
+  private CaseDTO createExpectedCaseDTO(
+      CaseContainerDTO caseFromCaseService,
+      boolean caseEvents,
       List<DeliveryChannel> expectedAllowedDeliveryChannels) {
 
-    CaseDTO expectedCaseResult = CaseDTO.builder().id(caseFromCaseService.getId())
-        .caseRef(caseFromCaseService.getCaseRef()).caseType(caseFromCaseService.getCaseType())
-        .allowedDeliveryChannels(expectedAllowedDeliveryChannels)
-        .createdDateTime(caseFromCaseService.getCreatedDateTime())
-        .addressLine1(caseFromCaseService.getAddressLine1())
-        .addressLine2(caseFromCaseService.getAddressLine2())
-        .addressLine3(caseFromCaseService.getAddressLine3())
-        .townName(caseFromCaseService.getTownName())
-        .region(caseFromCaseService.getRegion().substring(0, 1))
-        .postcode(caseFromCaseService.getPostcode())
-        .uprn(new UniquePropertyReferenceNumber(caseFromCaseService.getUprn()))
-        .handDelivery(caseFromCaseService.isHandDelivery()).build();
+    CaseDTO expectedCaseResult =
+        CaseDTO.builder()
+            .id(caseFromCaseService.getId())
+            .caseRef(caseFromCaseService.getCaseRef())
+            .caseType(caseFromCaseService.getCaseType())
+            .allowedDeliveryChannels(expectedAllowedDeliveryChannels)
+            .createdDateTime(caseFromCaseService.getCreatedDateTime())
+            .addressLine1(caseFromCaseService.getAddressLine1())
+            .addressLine2(caseFromCaseService.getAddressLine2())
+            .addressLine3(caseFromCaseService.getAddressLine3())
+            .townName(caseFromCaseService.getTownName())
+            .region(caseFromCaseService.getRegion().substring(0, 1))
+            .postcode(caseFromCaseService.getPostcode())
+            .uprn(new UniquePropertyReferenceNumber(caseFromCaseService.getUprn()))
+            .handDelivery(caseFromCaseService.isHandDelivery())
+            .build();
     if (caseEvents) {
-      List<CaseEventDTO> expectedCaseEvents = caseFromCaseService.getCaseEvents().stream()
-          .filter(e -> !e.getDescription().contains("Should be filtered out")).map(e -> {
-            CaseEventDTO expectedEvent = CaseEventDTO.builder().description(e.getDescription())
-                .category(e.getEventType()).createdDateTime(e.getCreatedDateTime()).build();
-            return expectedEvent;
-          }).collect(Collectors.toList());
+      List<CaseEventDTO> expectedCaseEvents =
+          caseFromCaseService
+              .getCaseEvents()
+              .stream()
+              .filter(e -> !e.getDescription().contains("Should be filtered out"))
+              .map(
+                  e -> {
+                    CaseEventDTO expectedEvent =
+                        CaseEventDTO.builder()
+                            .description(e.getDescription())
+                            .category(e.getEventType())
+                            .createdDateTime(e.getCreatedDateTime())
+                            .build();
+                    return expectedEvent;
+                  })
+              .collect(Collectors.toList());
       expectedCaseResult.setCaseEvents(expectedCaseEvents);
     }
     return expectedCaseResult;
@@ -790,8 +856,8 @@ public class CaseServiceImplTest {
     assertEquals(expectedCaseResult.getId(), results.getId());
     assertEquals(expectedCaseResult.getCaseRef(), results.getCaseRef());
     assertEquals(expectedCaseResult.getCaseType(), results.getCaseType());
-    assertEquals(expectedCaseResult.getAllowedDeliveryChannels(),
-        results.getAllowedDeliveryChannels());
+    assertEquals(
+        expectedCaseResult.getAllowedDeliveryChannels(), results.getAllowedDeliveryChannels());
     assertEquals(expectedCaseResult.isHandDelivery(), results.isHandDelivery());
 
     if (caseEventsExpected) {
@@ -840,26 +906,37 @@ public class CaseServiceImplTest {
     return requestBodyDTOFixture;
   }
 
-  private Product getProductFoundFixture(List<Product.CaseType> caseTypes,
-      Product.DeliveryChannel deliveryChannel, boolean individual) {
-    return Product.builder().caseTypes(caseTypes).description("foobar").fulfilmentCode("ABC123")
-        .language("eng").deliveryChannel(deliveryChannel)
+  private Product getProductFoundFixture(
+      List<Product.CaseType> caseTypes,
+      Product.DeliveryChannel deliveryChannel,
+      boolean individual) {
+    return Product.builder()
+        .caseTypes(caseTypes)
+        .description("foobar")
+        .fulfilmentCode("ABC123")
+        .language("eng")
+        .deliveryChannel(deliveryChannel)
         .regions(new ArrayList<Product.Region>(List.of(Product.Region.E)))
-        .requestChannels(new ArrayList<Product.RequestChannel>(
-            List.of(Product.RequestChannel.CC, Product.RequestChannel.FIELD)))
-        .individual(individual).build();
+        .requestChannels(
+            new ArrayList<Product.RequestChannel>(
+                List.of(Product.RequestChannel.CC, Product.RequestChannel.FIELD)))
+        .individual(individual)
+        .build();
   }
 
-  private Product getExpectedSearchCriteria(CaseContainerDTO caseData, String fulfilmentCode,
-      Product.DeliveryChannel deliveryChannel) {
-    return Product.builder().fulfilmentCode(fulfilmentCode)
-        .requestChannels(Arrays.asList(Product.RequestChannel.CC)).deliveryChannel(deliveryChannel)
+  private Product getExpectedSearchCriteria(
+      CaseContainerDTO caseData, String fulfilmentCode, Product.DeliveryChannel deliveryChannel) {
+    return Product.builder()
+        .fulfilmentCode(fulfilmentCode)
+        .requestChannels(Arrays.asList(Product.RequestChannel.CC))
+        .deliveryChannel(deliveryChannel)
         .regions(Arrays.asList(Product.Region.valueOf(caseData.getRegion().substring(0, 1))))
         .build();
   }
 
-  private void doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType caseType,
-      String title, String forename, String surname, boolean individual) throws Exception {
+  private void doVerifyFulfilmentRequestByPostFailsValidation(
+      Product.CaseType caseType, String title, String forename, String surname, boolean individual)
+      throws Exception {
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService =
         FixtureHelper.loadClassFixtures(CaseContainerDTO[].class).get(0);
@@ -868,8 +945,11 @@ public class CaseServiceImplTest {
     PostalFulfilmentRequestDTO requestBodyDTOFixture =
         getPostalFulfilmentRequestDTO(caseFromCaseService, title, forename, surname);
 
-    Product expectedSearchCriteria = getExpectedSearchCriteria(caseFromCaseService,
-        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
+    Product expectedSearchCriteria =
+        getExpectedSearchCriteria(
+            caseFromCaseService,
+            requestBodyDTOFixture.getFulfilmentCode(),
+            Product.DeliveryChannel.POST);
 
     // The mocked productReference will return this product
     Product productFoundFixture =
@@ -886,8 +966,9 @@ public class CaseServiceImplTest {
     }
   }
 
-  private void doFulfilmentRequestByPostSuccess(Product.CaseType caseType, String title,
-      String forename, String surname, boolean individual) throws Exception {
+  private void doFulfilmentRequestByPostSuccess(
+      Product.CaseType caseType, String title, String forename, String surname, boolean individual)
+      throws Exception {
     Mockito.clearInvocations(publisher);
 
     // Build results to be returned from search
@@ -898,8 +979,11 @@ public class CaseServiceImplTest {
     PostalFulfilmentRequestDTO requestBodyDTOFixture =
         getPostalFulfilmentRequestDTO(caseFromCaseService, title, forename, surname);
 
-    Product expectedSearchCriteria = getExpectedSearchCriteria(caseFromCaseService,
-        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
+    Product expectedSearchCriteria =
+        getExpectedSearchCriteria(
+            caseFromCaseService,
+            requestBodyDTOFixture.getFulfilmentCode(),
+            Product.DeliveryChannel.POST);
 
     // The mocked productReference will return this product
     Product productFoundFixture =
@@ -914,8 +998,8 @@ public class CaseServiceImplTest {
 
     // Validate the response
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), responseDTOFixture.getId());
-    verifyTimeInExpectedRange(timeBeforeInvocation, timeAfterInvocation,
-        responseDTOFixture.getDateTime());
+    verifyTimeInExpectedRange(
+        timeBeforeInvocation, timeAfterInvocation, responseDTOFixture.getDateTime());
 
     // Grab the published event
     ArgumentCaptor<EventType> eventTypeCaptor = ArgumentCaptor.forClass(EventType.class);
@@ -923,15 +1007,19 @@ public class CaseServiceImplTest {
     ArgumentCaptor<Channel> channelCaptor = ArgumentCaptor.forClass(Channel.class);
     ArgumentCaptor<FulfilmentRequest> fulfilmentRequestCaptor =
         ArgumentCaptor.forClass(FulfilmentRequest.class);
-    verify(publisher).sendEvent(eventTypeCaptor.capture(), sourceCaptor.capture(),
-        channelCaptor.capture(), fulfilmentRequestCaptor.capture());
+    verify(publisher)
+        .sendEvent(
+            eventTypeCaptor.capture(),
+            sourceCaptor.capture(),
+            channelCaptor.capture(),
+            fulfilmentRequestCaptor.capture());
 
     assertEquals(FULFILMENT_EVENT_TYPE_FIELD_VALUE, eventTypeCaptor.getValue());
     assertEquals(FULFILMENT_SOURCE_FIELD_VALUE, sourceCaptor.getValue());
     assertEquals(FULFILMENT_CHANNEL_FIELD_VALUE, channelCaptor.getValue());
     FulfilmentRequest actualFulfilmentRequest = fulfilmentRequestCaptor.getValue();
-    assertEquals(requestBodyDTOFixture.getFulfilmentCode(),
-        actualFulfilmentRequest.getFulfilmentCode());
+    assertEquals(
+        requestBodyDTOFixture.getFulfilmentCode(), actualFulfilmentRequest.getFulfilmentCode());
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), actualFulfilmentRequest.getCaseId());
 
     if (caseType == Product.CaseType.HH && individual) {
@@ -972,8 +1060,11 @@ public class CaseServiceImplTest {
 
     SMSFulfilmentRequestDTO requestBodyDTOFixture = getSMSFulfilmentRequestDTO(caseFromCaseService);
 
-    Product expectedSearchCriteria = getExpectedSearchCriteria(caseFromCaseService,
-        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.SMS);
+    Product expectedSearchCriteria =
+        getExpectedSearchCriteria(
+            caseFromCaseService,
+            requestBodyDTOFixture.getFulfilmentCode(),
+            Product.DeliveryChannel.SMS);
 
     // The mocked productReference will return this product
     Product productFoundFixture =
@@ -996,16 +1087,20 @@ public class CaseServiceImplTest {
     ArgumentCaptor<Channel> channelCaptor = ArgumentCaptor.forClass(Channel.class);
     ArgumentCaptor<FulfilmentRequest> fulfilmentRequestCaptor =
         ArgumentCaptor.forClass(FulfilmentRequest.class);
-    verify(publisher).sendEvent(eventTypeCaptor.capture(), sourceCaptor.capture(),
-        channelCaptor.capture(), fulfilmentRequestCaptor.capture());
+    verify(publisher)
+        .sendEvent(
+            eventTypeCaptor.capture(),
+            sourceCaptor.capture(),
+            channelCaptor.capture(),
+            fulfilmentRequestCaptor.capture());
 
     assertEquals(FULFILMENT_EVENT_TYPE_FIELD_VALUE, eventTypeCaptor.getValue());
     assertEquals(FULFILMENT_SOURCE_FIELD_VALUE, sourceCaptor.getValue());
     assertEquals(FULFILMENT_CHANNEL_FIELD_VALUE, channelCaptor.getValue());
 
     FulfilmentRequest actualFulfilmentRequest = fulfilmentRequestCaptor.getValue();
-    assertEquals(requestBodyDTOFixture.getFulfilmentCode(),
-        actualFulfilmentRequest.getFulfilmentCode());
+    assertEquals(
+        requestBodyDTOFixture.getFulfilmentCode(), actualFulfilmentRequest.getFulfilmentCode());
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), actualFulfilmentRequest.getCaseId());
 
     if (caseType == Product.CaseType.HH && individual) {

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -37,6 +37,7 @@ import uk.gov.ons.ctp.common.event.EventPublisher;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.EventPublisher.Source;
+import uk.gov.ons.ctp.common.event.model.Address;
 import uk.gov.ons.ctp.common.event.model.AddressCompact;
 import uk.gov.ons.ctp.common.event.model.Contact;
 import uk.gov.ons.ctp.common.event.model.EventPayload;
@@ -1033,6 +1034,19 @@ public class CaseServiceImplTest {
     assertEquals(requestBodyDTOFixture.getSurname(), actualContact.getSurname());
     assertEquals(null, actualContact.getEmail());
     assertEquals(null, actualContact.getTelNo());
+
+    Address actualAddress = actualFulfilmentRequest.getAddress();
+    assertEquals(caseFromCaseService.getAddressLine1(), actualAddress.getAddressLine1());
+    assertEquals(caseFromCaseService.getAddressLine2(), actualAddress.getAddressLine2());
+    assertEquals(caseFromCaseService.getAddressLine3(), actualAddress.getAddressLine3());
+    assertEquals(caseFromCaseService.getTownName(), actualAddress.getTownName());
+    assertEquals(caseFromCaseService.getPostcode(), actualAddress.getPostcode());
+    assertEquals(caseFromCaseService.getRegion(), actualAddress.getRegion());
+    assertEquals(caseFromCaseService.getLatitude(), actualAddress.getLatitude());
+    assertEquals(caseFromCaseService.getLongitude(), actualAddress.getLongitude());
+    assertEquals(caseFromCaseService.getUprn(), actualAddress.getUprn());
+    assertEquals(caseFromCaseService.getArid(), actualAddress.getArid());
+    assertEquals(caseFromCaseService.getEstabType(), actualAddress.getEstabType());
   }
 
   private void doFulfilmentRequestBySMSSuccess(Product.CaseType caseType, boolean individual)

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -10,7 +10,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.verify;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -75,21 +74,29 @@ import uk.gov.ons.ctp.integration.eqlaunch.service.impl.EqLaunchServiceImpl;
  * which would deal with actually sending a HTTP request to the case service.
  */
 public class CaseServiceImplTest {
-  @Mock AppConfig appConfig = new AppConfig();
+  @Mock
+  AppConfig appConfig = new AppConfig();
 
-  @Mock ProductReference productReference;
+  @Mock
+  ProductReference productReference;
 
-  @Mock EventPublisher publisher;
+  @Mock
+  EventPublisher publisher;
 
-  @Mock CaseServiceClientServiceImpl caseServiceClient;
+  @Mock
+  CaseServiceClientServiceImpl caseServiceClient;
 
-  @Mock EqLaunchService eqLaunchService = new EqLaunchServiceImpl();
+  @Mock
+  EqLaunchService eqLaunchService = new EqLaunchServiceImpl();
 
-  @Mock EventPublisher eventPublisher;
+  @Mock
+  EventPublisher eventPublisher;
 
-  @Spy private MapperFacade mapperFacade = new CCSvcBeanMapper();
+  @Spy
+  private MapperFacade mapperFacade = new CCSvcBeanMapper();
 
-  @InjectMocks CaseService target = new CaseServiceImpl();
+  @InjectMocks
+  CaseService target = new CaseServiceImpl();
 
   private UUID uuid = UUID.fromString("b7565b5e-1396-4965-91a2-918c0d3642ed");
 
@@ -122,16 +129,16 @@ public class CaseServiceImplTest {
   public void testFulfilmentRequestByPost_individualFailsWithNullContactDetails() throws Exception {
     // All of the following fail validation because one of the contact detail fields is always null
     // or empty
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Product.CaseType.HH, null, "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, null, "John", "Smith",
+        true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "", "John", "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", null, "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", "", "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", "John", null, true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.HH, "Mr", "John", "", true);
 
-    doVerifyFulfilmentRequestByPostFailsValidation(
-        Product.CaseType.CE, null, "John", "Smith", true);
+    doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, null, "John", "Smith",
+        true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "", "John", "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "Mr", null, "Smith", true);
     doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType.CE, "Mr", "", "Smith", true);
@@ -169,9 +176,8 @@ public class CaseServiceImplTest {
     PostalFulfilmentRequestDTO requestBodyDTOFixture =
         getPostalFulfilmentRequestDTO(caseData, "Mr", "Mickey", "Mouse");
 
-    Product expectedSearchCriteria =
-        getExpectedSearchCriteria(
-            caseData, requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
+    Product expectedSearchCriteria = getExpectedSearchCriteria(caseData,
+        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
 
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>());
@@ -201,15 +207,11 @@ public class CaseServiceImplTest {
     PostalFulfilmentRequestDTO requestBodyDTOFixture =
         getPostalFulfilmentRequestDTO(caseFromCaseService, "Mrs", "Sally", "Smurf");
 
-    Product expectedSearchCriteria =
-        getExpectedSearchCriteria(
-            caseFromCaseService,
-            requestBodyDTOFixture.getFulfilmentCode(),
-            Product.DeliveryChannel.POST);
+    Product expectedSearchCriteria = getExpectedSearchCriteria(caseFromCaseService,
+        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
 
-    Product productFoundFixture =
-        getProductFoundFixture(
-            Arrays.asList(Product.CaseType.SPG), Product.DeliveryChannel.POST, false);
+    Product productFoundFixture = getProductFoundFixture(Arrays.asList(Product.CaseType.SPG),
+        Product.DeliveryChannel.POST, false);
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
 
@@ -242,9 +244,8 @@ public class CaseServiceImplTest {
 
     SMSFulfilmentRequestDTO requestBodyDTOFixture = getSMSFulfilmentRequestDTO(caseData);
 
-    Product expectedSearchCriteria =
-        getExpectedSearchCriteria(
-            caseData, requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.SMS);
+    Product expectedSearchCriteria = getExpectedSearchCriteria(caseData,
+        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.SMS);
 
     Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
         .thenReturn(new ArrayList<Product>());
@@ -263,55 +264,55 @@ public class CaseServiceImplTest {
   public void testGetHouseholdCaseByCaseId_withCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetHouseholdCaseByCaseId_withNoCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseId_caseHHhandDeliveryTrue() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.HH, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.HH, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCommunalCaseByCaseId_withCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.CE, HAND_DELIVERY_TRUE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.CE, HAND_DELIVERY_TRUE, CASE_EVENTS_TRUE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCommunalCaseByCaseId_withNoCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.CE, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.CE, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseId_caseSPGhandDeliveryTrue() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels = Arrays.asList(DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.SPG, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.SPG, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseId_caseSPGhandDeliveryFalse() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.SPG, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.SPG, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
+        expectedDeliveryChannels);
   }
 
   @Test
@@ -376,11 +377,8 @@ public class CaseServiceImplTest {
     List<CaseDTO> results = target.getCaseByUPRN(uprn, new CaseRequestDTO(caseEvents));
     assertEquals(1, results.size());
 
-    CaseDTO expectedCaseResult =
-        createExpectedCaseDTO(
-            caseFromCaseService.get(1),
-            caseEvents,
-            Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+    CaseDTO expectedCaseResult = createExpectedCaseDTO(caseFromCaseService.get(1), caseEvents,
+        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
     verifyCase(results.get(0), expectedCaseResult, caseEvents);
   }
 
@@ -399,9 +397,8 @@ public class CaseServiceImplTest {
     doTestGetCasesByUprn("SPG", false, Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
   }
 
-  private void doTestGetCasesByUprn(
-      String caseType, boolean handDelivery, List<DeliveryChannel> expectedDeliveryChannels)
-      throws Exception {
+  private void doTestGetCasesByUprn(String caseType, boolean handDelivery,
+      List<DeliveryChannel> expectedDeliveryChannels) throws Exception {
     UniquePropertyReferenceNumber uprn = new UniquePropertyReferenceNumber(334999999999L);
 
     List<CaseContainerDTO> caseFromCaseService =
@@ -425,55 +422,55 @@ public class CaseServiceImplTest {
   public void testGetHouseholdCaseByCaseRef_withCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(
-        CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetHouseholdCaseByCaseRef_withNoCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(
-        CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(CaseType.HH, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseRef_caseHHhandDeliveryTrue() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(
-        CaseType.HH, HAND_DELIVERY_TRUE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(CaseType.HH, HAND_DELIVERY_TRUE, CASE_EVENTS_TRUE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCommunalCaseByCaseRef_withCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(
-        CaseType.CE, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE, expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(CaseType.CE, HAND_DELIVERY_FALSE, CASE_EVENTS_TRUE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCommunalCaseByCaseRef_withNoCaseDetails() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(
-        CaseType.CE, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(CaseType.CE, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseRef_caseSPGhandDeliveryTrue() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels = Arrays.asList(DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(
-        CaseType.SPG, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(CaseType.SPG, HAND_DELIVERY_TRUE, CASE_EVENTS_FALSE,
+        expectedDeliveryChannels);
   }
 
   @Test
   public void testGetCaseByCaseRef_caseSPGhandDeliveryFalse() throws Exception {
     List<DeliveryChannel> expectedDeliveryChannels =
         Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseRef(
-        CaseType.SPG, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE, expectedDeliveryChannels);
+    doTestGetCaseByCaseRef(CaseType.SPG, HAND_DELIVERY_FALSE, CASE_EVENTS_FALSE,
+        expectedDeliveryChannels);
   }
 
   @Test
@@ -585,18 +582,11 @@ public class CaseServiceImplTest {
     Mockito.when(appConfig.getEq()).thenReturn(eqConfig);
 
     // Mock out building of launch payload
-    Mockito.when(
-            eqLaunchService.getEqLaunchJwe(
-                eq(Language.ENGLISH),
-                eq(uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API),
-                eq(uk.gov.ons.ctp.common.model.Channel.CC),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                isNull())) // keystore
+    Mockito
+        .when(eqLaunchService.getEqLaunchJwe(eq(Language.ENGLISH),
+            eq(uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API),
+            eq(uk.gov.ons.ctp.common.model.Channel.CC), any(), any(), any(), any(), any(), any(),
+            isNull())) // keystore
         .thenReturn("simulated-encrypted-payload");
 
     // Build DTO for launch request
@@ -610,8 +600,8 @@ public class CaseServiceImplTest {
 
     // Verify call to RM to get qid is using the correct individual case id
     ArgumentCaptor<UUID> individualCaseIdCaptor = ArgumentCaptor.forClass(UUID.class);
-    Mockito.verify(caseServiceClient)
-        .getSingleUseQuestionnaireId(any(), eq(individual), individualCaseIdCaptor.capture());
+    Mockito.verify(caseServiceClient).getSingleUseQuestionnaireId(any(), eq(individual),
+        individualCaseIdCaptor.capture());
     if (caseType.equals("HH") && individual) {
       assertNotEquals(uuid, individualCaseIdCaptor.getValue()); // expecting newly allocated uuid
     } else {
@@ -620,18 +610,11 @@ public class CaseServiceImplTest {
 
     // Verify correct data passed to eqLauncher
     ArgumentCaptor<CaseContainerDTO> caseCaptor = ArgumentCaptor.forClass(CaseContainerDTO.class);
-    Mockito.verify(eqLaunchService)
-        .getEqLaunchJwe(
-            eq(Language.ENGLISH),
-            eq(uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API),
-            eq(uk.gov.ons.ctp.common.model.Channel.CC),
-            caseCaptor.capture(),
-            eq("1234"), // agent
-            eq(questionnaireId),
-            eq(formType),
-            isNull(), // accountServiceUrl
-            isNull(),
-            any()); // keystore
+    Mockito.verify(eqLaunchService).getEqLaunchJwe(eq(Language.ENGLISH),
+        eq(uk.gov.ons.ctp.common.model.Source.CONTACT_CENTRE_API),
+        eq(uk.gov.ons.ctp.common.model.Channel.CC), caseCaptor.capture(), eq("1234"), // agent
+        eq(questionnaireId), eq(formType), isNull(), // accountServiceUrl
+        isNull(), any()); // keystore
 
     // Verify case details passed to eqLauncher
     CaseContainerDTO capturedCase = caseCaptor.getValue();
@@ -645,12 +628,9 @@ public class CaseServiceImplTest {
     // Verify surveyLaunched event published
     ArgumentCaptor<SurveyLaunchedResponse> surveyLaunchedResponseCaptor =
         ArgumentCaptor.forClass(SurveyLaunchedResponse.class);
-    Mockito.verify(eventPublisher)
-        .sendEvent(
-            eq(EventType.SURVEY_LAUNCHED),
-            eq(Source.CONTACT_CENTRE_API),
-            eq(Channel.CC),
-            (EventPayload) surveyLaunchedResponseCaptor.capture());
+    Mockito.verify(eventPublisher).sendEvent(eq(EventType.SURVEY_LAUNCHED),
+        eq(Source.CONTACT_CENTRE_API), eq(Channel.CC),
+        (EventPayload) surveyLaunchedResponseCaptor.capture());
 
     // Verify payload for surveyLaunched event
     if (caseType.equals("HH") && individual) {
@@ -663,25 +643,13 @@ public class CaseServiceImplTest {
     assertEquals("1234", surveyLaunchedResponseCaptor.getValue().getAgentId());
   }
 
-  private void doRespondentRefusalTest(
-      UUID caseId, UUID expectedEventCaseId, String expectedResponseCaseId, Date dateTime)
-      throws Exception {
-    RefusalRequestDTO refusalPayload =
-        RefusalRequestDTO.builder()
-            .caseId(caseId == null ? null : caseId.toString())
-            .notes("Description of refusal")
-            .title("Mr")
-            .forename("Steve")
-            .surname("Jones")
-            .telNo("+447890000000")
-            .addressLine1("1 High Street")
-            .addressLine2("Delph")
-            .addressLine3("Oldham")
-            .townName("Manchester")
-            .postcode("OL3 5DJ")
-            .region("E")
-            .dateTime(dateTime)
-            .build();
+  private void doRespondentRefusalTest(UUID caseId, UUID expectedEventCaseId,
+      String expectedResponseCaseId, Date dateTime) throws Exception {
+    RefusalRequestDTO refusalPayload = RefusalRequestDTO.builder()
+        .caseId(caseId == null ? null : caseId.toString()).notes("Description of refusal")
+        .title("Mr").forename("Steve").surname("Jones").telNo("+447890000000")
+        .addressLine1("1 High Street").addressLine2("Delph").addressLine3("Oldham")
+        .townName("Manchester").postcode("OL3 5DJ").region("E").dateTime(dateTime).build();
 
     // report the refusal
     long timeBeforeInvocation = System.currentTimeMillis();
@@ -690,8 +658,8 @@ public class CaseServiceImplTest {
 
     // Validate the response to the refusal
     assertEquals(expectedResponseCaseId, refusalResponse.getId());
-    verifyTimeInExpectedRange(
-        timeBeforeInvocation, timeAfterInvocation, refusalResponse.getDateTime());
+    verifyTimeInExpectedRange(timeBeforeInvocation, timeAfterInvocation,
+        refusalResponse.getDateTime());
 
     // Grab the published event
     ArgumentCaptor<EventType> eventTypeCaptor = ArgumentCaptor.forClass(EventType.class);
@@ -699,12 +667,8 @@ public class CaseServiceImplTest {
     ArgumentCaptor<Channel> channelCaptor = ArgumentCaptor.forClass(Channel.class);
     ArgumentCaptor<RespondentRefusalDetails> refusalEventCaptor =
         ArgumentCaptor.forClass(RespondentRefusalDetails.class);
-    verify(publisher)
-        .sendEvent(
-            eventTypeCaptor.capture(),
-            sourceCaptor.capture(),
-            channelCaptor.capture(),
-            refusalEventCaptor.capture());
+    verify(publisher).sendEvent(eventTypeCaptor.capture(), sourceCaptor.capture(),
+        channelCaptor.capture(), refusalEventCaptor.capture());
 
     assertEquals(REFUSAL_EVENT_TYPE_FIELD_VALUE, eventTypeCaptor.getValue());
     assertEquals(REFUSAL_SOURCE_FIELD_VALUE, sourceCaptor.getValue());
@@ -732,12 +696,8 @@ public class CaseServiceImplTest {
     assertTrue(actualInMillis + " not before " + maxAllowed, actualInMillis <= maxAllowed);
   }
 
-  private void doTestGetCaseByCaseId(
-      CaseType caseType,
-      boolean handDelivery,
-      boolean caseEvents,
-      List<DeliveryChannel> expectedAllowedDeliveryChannels)
-      throws Exception {
+  private void doTestGetCaseByCaseId(CaseType caseType, boolean handDelivery, boolean caseEvents,
+      List<DeliveryChannel> expectedAllowedDeliveryChannels) throws Exception {
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService =
         FixtureHelper.loadClassFixtures(CaseContainerDTO[].class).get(0);
@@ -770,27 +730,17 @@ public class CaseServiceImplTest {
     List<CaseDTO> results = target.getCaseByUPRN(uprn, requestParams);
 
     // Verify response
-    CaseDTO expectedCaseResult0 =
-        createExpectedCaseDTO(
-            caseFromCaseService.get(0),
-            caseEvents,
-            Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+    CaseDTO expectedCaseResult0 = createExpectedCaseDTO(caseFromCaseService.get(0), caseEvents,
+        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
     verifyCase(results.get(0), expectedCaseResult0, caseEvents);
 
-    CaseDTO expectedCaseResult1 =
-        createExpectedCaseDTO(
-            caseFromCaseService.get(1),
-            caseEvents,
-            Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+    CaseDTO expectedCaseResult1 = createExpectedCaseDTO(caseFromCaseService.get(1), caseEvents,
+        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
     verifyCase(results.get(1), expectedCaseResult1, caseEvents);
   }
 
-  private void doTestGetCaseByCaseRef(
-      CaseType caseType,
-      boolean handDelivery,
-      boolean caseEvents,
-      List<DeliveryChannel> expectedAllowedDeliveryChannels)
-      throws Exception {
+  private void doTestGetCaseByCaseRef(CaseType caseType, boolean handDelivery, boolean caseEvents,
+      List<DeliveryChannel> expectedAllowedDeliveryChannels) throws Exception {
     long testCaseRef = 88234544;
 
     // Build results to be returned from search
@@ -808,44 +758,28 @@ public class CaseServiceImplTest {
     verifyCase(results, expectedCaseResult, caseEvents);
   }
 
-  private CaseDTO createExpectedCaseDTO(
-      CaseContainerDTO caseFromCaseService,
-      boolean caseEvents,
+  private CaseDTO createExpectedCaseDTO(CaseContainerDTO caseFromCaseService, boolean caseEvents,
       List<DeliveryChannel> expectedAllowedDeliveryChannels) {
 
-    CaseDTO expectedCaseResult =
-        CaseDTO.builder()
-            .id(caseFromCaseService.getId())
-            .caseRef(caseFromCaseService.getCaseRef())
-            .caseType(caseFromCaseService.getCaseType())
-            .allowedDeliveryChannels(expectedAllowedDeliveryChannels)
-            .createdDateTime(caseFromCaseService.getCreatedDateTime())
-            .addressLine1(caseFromCaseService.getAddressLine1())
-            .addressLine2(caseFromCaseService.getAddressLine2())
-            .addressLine3(caseFromCaseService.getAddressLine3())
-            .townName(caseFromCaseService.getTownName())
-            .region(caseFromCaseService.getRegion().substring(0, 1))
-            .postcode(caseFromCaseService.getPostcode())
-            .uprn(new UniquePropertyReferenceNumber(caseFromCaseService.getUprn()))
-            .handDelivery(caseFromCaseService.isHandDelivery())
-            .build();
+    CaseDTO expectedCaseResult = CaseDTO.builder().id(caseFromCaseService.getId())
+        .caseRef(caseFromCaseService.getCaseRef()).caseType(caseFromCaseService.getCaseType())
+        .allowedDeliveryChannels(expectedAllowedDeliveryChannels)
+        .createdDateTime(caseFromCaseService.getCreatedDateTime())
+        .addressLine1(caseFromCaseService.getAddressLine1())
+        .addressLine2(caseFromCaseService.getAddressLine2())
+        .addressLine3(caseFromCaseService.getAddressLine3())
+        .townName(caseFromCaseService.getTownName())
+        .region(caseFromCaseService.getRegion().substring(0, 1))
+        .postcode(caseFromCaseService.getPostcode())
+        .uprn(new UniquePropertyReferenceNumber(caseFromCaseService.getUprn()))
+        .handDelivery(caseFromCaseService.isHandDelivery()).build();
     if (caseEvents) {
-      List<CaseEventDTO> expectedCaseEvents =
-          caseFromCaseService
-              .getCaseEvents()
-              .stream()
-              .filter(e -> !e.getDescription().contains("Should be filtered out"))
-              .map(
-                  e -> {
-                    CaseEventDTO expectedEvent =
-                        CaseEventDTO.builder()
-                            .description(e.getDescription())
-                            .category(e.getEventType())
-                            .createdDateTime(e.getCreatedDateTime())
-                            .build();
-                    return expectedEvent;
-                  })
-              .collect(Collectors.toList());
+      List<CaseEventDTO> expectedCaseEvents = caseFromCaseService.getCaseEvents().stream()
+          .filter(e -> !e.getDescription().contains("Should be filtered out")).map(e -> {
+            CaseEventDTO expectedEvent = CaseEventDTO.builder().description(e.getDescription())
+                .category(e.getEventType()).createdDateTime(e.getCreatedDateTime()).build();
+            return expectedEvent;
+          }).collect(Collectors.toList());
       expectedCaseResult.setCaseEvents(expectedCaseEvents);
     }
     return expectedCaseResult;
@@ -856,8 +790,8 @@ public class CaseServiceImplTest {
     assertEquals(expectedCaseResult.getId(), results.getId());
     assertEquals(expectedCaseResult.getCaseRef(), results.getCaseRef());
     assertEquals(expectedCaseResult.getCaseType(), results.getCaseType());
-    assertEquals(
-        expectedCaseResult.getAllowedDeliveryChannels(), results.getAllowedDeliveryChannels());
+    assertEquals(expectedCaseResult.getAllowedDeliveryChannels(),
+        results.getAllowedDeliveryChannels());
     assertEquals(expectedCaseResult.isHandDelivery(), results.isHandDelivery());
 
     if (caseEventsExpected) {
@@ -906,37 +840,26 @@ public class CaseServiceImplTest {
     return requestBodyDTOFixture;
   }
 
-  private Product getProductFoundFixture(
-      List<Product.CaseType> caseTypes,
-      Product.DeliveryChannel deliveryChannel,
-      boolean individual) {
-    return Product.builder()
-        .caseTypes(caseTypes)
-        .description("foobar")
-        .fulfilmentCode("ABC123")
-        .language("eng")
-        .deliveryChannel(deliveryChannel)
+  private Product getProductFoundFixture(List<Product.CaseType> caseTypes,
+      Product.DeliveryChannel deliveryChannel, boolean individual) {
+    return Product.builder().caseTypes(caseTypes).description("foobar").fulfilmentCode("ABC123")
+        .language("eng").deliveryChannel(deliveryChannel)
         .regions(new ArrayList<Product.Region>(List.of(Product.Region.E)))
-        .requestChannels(
-            new ArrayList<Product.RequestChannel>(
-                List.of(Product.RequestChannel.CC, Product.RequestChannel.FIELD)))
-        .individual(individual)
-        .build();
+        .requestChannels(new ArrayList<Product.RequestChannel>(
+            List.of(Product.RequestChannel.CC, Product.RequestChannel.FIELD)))
+        .individual(individual).build();
   }
 
-  private Product getExpectedSearchCriteria(
-      CaseContainerDTO caseData, String fulfilmentCode, Product.DeliveryChannel deliveryChannel) {
-    return Product.builder()
-        .fulfilmentCode(fulfilmentCode)
-        .requestChannels(Arrays.asList(Product.RequestChannel.CC))
-        .deliveryChannel(deliveryChannel)
+  private Product getExpectedSearchCriteria(CaseContainerDTO caseData, String fulfilmentCode,
+      Product.DeliveryChannel deliveryChannel) {
+    return Product.builder().fulfilmentCode(fulfilmentCode)
+        .requestChannels(Arrays.asList(Product.RequestChannel.CC)).deliveryChannel(deliveryChannel)
         .regions(Arrays.asList(Product.Region.valueOf(caseData.getRegion().substring(0, 1))))
         .build();
   }
 
-  private void doVerifyFulfilmentRequestByPostFailsValidation(
-      Product.CaseType caseType, String title, String forename, String surname, boolean individual)
-      throws Exception {
+  private void doVerifyFulfilmentRequestByPostFailsValidation(Product.CaseType caseType,
+      String title, String forename, String surname, boolean individual) throws Exception {
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService =
         FixtureHelper.loadClassFixtures(CaseContainerDTO[].class).get(0);
@@ -945,11 +868,8 @@ public class CaseServiceImplTest {
     PostalFulfilmentRequestDTO requestBodyDTOFixture =
         getPostalFulfilmentRequestDTO(caseFromCaseService, title, forename, surname);
 
-    Product expectedSearchCriteria =
-        getExpectedSearchCriteria(
-            caseFromCaseService,
-            requestBodyDTOFixture.getFulfilmentCode(),
-            Product.DeliveryChannel.POST);
+    Product expectedSearchCriteria = getExpectedSearchCriteria(caseFromCaseService,
+        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
 
     // The mocked productReference will return this product
     Product productFoundFixture =
@@ -966,9 +886,8 @@ public class CaseServiceImplTest {
     }
   }
 
-  private void doFulfilmentRequestByPostSuccess(
-      Product.CaseType caseType, String title, String forename, String surname, boolean individual)
-      throws Exception {
+  private void doFulfilmentRequestByPostSuccess(Product.CaseType caseType, String title,
+      String forename, String surname, boolean individual) throws Exception {
     Mockito.clearInvocations(publisher);
 
     // Build results to be returned from search
@@ -979,11 +898,8 @@ public class CaseServiceImplTest {
     PostalFulfilmentRequestDTO requestBodyDTOFixture =
         getPostalFulfilmentRequestDTO(caseFromCaseService, title, forename, surname);
 
-    Product expectedSearchCriteria =
-        getExpectedSearchCriteria(
-            caseFromCaseService,
-            requestBodyDTOFixture.getFulfilmentCode(),
-            Product.DeliveryChannel.POST);
+    Product expectedSearchCriteria = getExpectedSearchCriteria(caseFromCaseService,
+        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.POST);
 
     // The mocked productReference will return this product
     Product productFoundFixture =
@@ -998,8 +914,8 @@ public class CaseServiceImplTest {
 
     // Validate the response
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), responseDTOFixture.getId());
-    verifyTimeInExpectedRange(
-        timeBeforeInvocation, timeAfterInvocation, responseDTOFixture.getDateTime());
+    verifyTimeInExpectedRange(timeBeforeInvocation, timeAfterInvocation,
+        responseDTOFixture.getDateTime());
 
     // Grab the published event
     ArgumentCaptor<EventType> eventTypeCaptor = ArgumentCaptor.forClass(EventType.class);
@@ -1007,19 +923,15 @@ public class CaseServiceImplTest {
     ArgumentCaptor<Channel> channelCaptor = ArgumentCaptor.forClass(Channel.class);
     ArgumentCaptor<FulfilmentRequest> fulfilmentRequestCaptor =
         ArgumentCaptor.forClass(FulfilmentRequest.class);
-    verify(publisher)
-        .sendEvent(
-            eventTypeCaptor.capture(),
-            sourceCaptor.capture(),
-            channelCaptor.capture(),
-            fulfilmentRequestCaptor.capture());
+    verify(publisher).sendEvent(eventTypeCaptor.capture(), sourceCaptor.capture(),
+        channelCaptor.capture(), fulfilmentRequestCaptor.capture());
 
     assertEquals(FULFILMENT_EVENT_TYPE_FIELD_VALUE, eventTypeCaptor.getValue());
     assertEquals(FULFILMENT_SOURCE_FIELD_VALUE, sourceCaptor.getValue());
     assertEquals(FULFILMENT_CHANNEL_FIELD_VALUE, channelCaptor.getValue());
     FulfilmentRequest actualFulfilmentRequest = fulfilmentRequestCaptor.getValue();
-    assertEquals(
-        requestBodyDTOFixture.getFulfilmentCode(), actualFulfilmentRequest.getFulfilmentCode());
+    assertEquals(requestBodyDTOFixture.getFulfilmentCode(),
+        actualFulfilmentRequest.getFulfilmentCode());
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), actualFulfilmentRequest.getCaseId());
 
     if (caseType == Product.CaseType.HH && individual) {
@@ -1046,6 +958,7 @@ public class CaseServiceImplTest {
     assertEquals(caseFromCaseService.getLongitude(), actualAddress.getLongitude());
     assertEquals(caseFromCaseService.getUprn(), actualAddress.getUprn());
     assertEquals(caseFromCaseService.getArid(), actualAddress.getArid());
+    assertEquals(caseFromCaseService.getAddressType(), actualAddress.getAddressType());
     assertEquals(caseFromCaseService.getEstabType(), actualAddress.getEstabType());
   }
 
@@ -1059,11 +972,8 @@ public class CaseServiceImplTest {
 
     SMSFulfilmentRequestDTO requestBodyDTOFixture = getSMSFulfilmentRequestDTO(caseFromCaseService);
 
-    Product expectedSearchCriteria =
-        getExpectedSearchCriteria(
-            caseFromCaseService,
-            requestBodyDTOFixture.getFulfilmentCode(),
-            Product.DeliveryChannel.SMS);
+    Product expectedSearchCriteria = getExpectedSearchCriteria(caseFromCaseService,
+        requestBodyDTOFixture.getFulfilmentCode(), Product.DeliveryChannel.SMS);
 
     // The mocked productReference will return this product
     Product productFoundFixture =
@@ -1086,20 +996,16 @@ public class CaseServiceImplTest {
     ArgumentCaptor<Channel> channelCaptor = ArgumentCaptor.forClass(Channel.class);
     ArgumentCaptor<FulfilmentRequest> fulfilmentRequestCaptor =
         ArgumentCaptor.forClass(FulfilmentRequest.class);
-    verify(publisher)
-        .sendEvent(
-            eventTypeCaptor.capture(),
-            sourceCaptor.capture(),
-            channelCaptor.capture(),
-            fulfilmentRequestCaptor.capture());
+    verify(publisher).sendEvent(eventTypeCaptor.capture(), sourceCaptor.capture(),
+        channelCaptor.capture(), fulfilmentRequestCaptor.capture());
 
     assertEquals(FULFILMENT_EVENT_TYPE_FIELD_VALUE, eventTypeCaptor.getValue());
     assertEquals(FULFILMENT_SOURCE_FIELD_VALUE, sourceCaptor.getValue());
     assertEquals(FULFILMENT_CHANNEL_FIELD_VALUE, channelCaptor.getValue());
 
     FulfilmentRequest actualFulfilmentRequest = fulfilmentRequestCaptor.getValue();
-    assertEquals(
-        requestBodyDTOFixture.getFulfilmentCode(), actualFulfilmentRequest.getFulfilmentCode());
+    assertEquals(requestBodyDTOFixture.getFulfilmentCode(),
+        actualFulfilmentRequest.getFulfilmentCode());
     assertEquals(requestBodyDTOFixture.getCaseId().toString(), actualFulfilmentRequest.getCaseId());
 
     if (caseType == Product.CaseType.HH && individual) {


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is required because the FulfilmentRequest event, which is generated by the CCSVC when it receives a 'fulfilmentRequestByPost' request, needs to include Address details, 
which are currently empty.

It has not yet been decided (by the business) whether the address details, which are sent to RM in the FulfilmentRequest event, should come from the RM case or, if the address has been modified 
but not yet validated, should be the modified ones. Currently the address is always taken from the RM case.

# How to test?
These changes can be tested using postman by doing as follows:
1. Run rabbitmq, mock case service, and this branch of the contact centre service.
2. Go to the rabbitmq management console and purge the queue, named event.fulfilment.request, to make sure that it is empty: http://localhost:46672/#/queues/%2F/event.fulfilment.request
3. Add the following JSON request to the mock case service using this endpoint: http://localhost:8161/cases/data/cases/add

    [{
        "caseRef": "123123",
        "arid": "2344266233",
        "estabArid": "AABBCC",
        "estabType": "ET",
        "uprn": "1347459999",
        "createdDateTime": "2019-04-14T13:45:26.564+01:00",
        "addressLine1": "Napier House",
        "addressLine2": "88 Harbour Street",
        "addressLine3": "Parkhead",
        "townName": "Glasgow",
        "postcode": "G1 2AA",
        "organisationName": "ON",
        "addressLevel": "E",
        "abpCode": "AACC",
        "latitude": "41.40338",
        "longitude": "2.17403",
        "oa": "EE22",
        "lsoa": "x1",
        "msoa": "x2",
        "lad": "H1",
        "caseEvents": [
            {
                "id": "101",
                "eventType": "CASE_UPDATED",
                "description": "Initial creation of case",
                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
            },
            {
                "id": "102",
                "eventType": null,
                "description": "Create Household Visit",
                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
            }
        ],
        "id": "9b90abb2-6105-4d0d-9dc9-1054b61a29f6",
        "caseType": "HH",
        "region": "E",
        "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
        "surveyType": "CENSUS",
        "handDelivery": false
    }] 

4. Go to the following POST endpoint: http://localhost:8171/cases/9b90abb2-6105-4d0d-9dc9-1054b61a29f6/fulfilment/post
5. From there send the following request body:

{
	"caseId": "9b90abb2-6105-4d0d-9dc9-1054b61a29f6",
	"title": "Mrs",
	"forename": "Sally",
	"surname": "Smurf",
	"fulfilmentCode": "P_OR_H1",
	"dateTime": "2019-04-14T13:45:26.564+01:00"
} 

6. Go back to the rabbitmq management console and make sure that there is now 1 message in the queue named event.fulfilment.request
7. Check that the message is a FULFILMENT_REQUESTED event that contains all the address fields as expected:
{"event":{"type":"FULFILMENT_REQUESTED","source":"CONTACT_CENTRE_API","channel":"CC","dateTime":"2020-03-11T13:12:10.975Z","transactionId":"dd8acba8-006c-42f5-ad05-5208045ccdfd"},"payload":{"fulfilmentRequest":{"fulfilmentCode":"P_OR_H1","caseId":"3305e937-6fb1-4ce1-9d4c-077f147789aa","individualCaseId":null,"address":{"addressLine1":"Napier House","addressLine2":"88 Harbour Street","addressLine3":"Parkhead","townName":"Glasgow","postcode":"G1 2AA","region":"E","latitude":"41.40338","longitude":"2.17403","uprn":"1347459999","arid":"2344266233","addressType":null,"estabType":"ET"},"contact":{"title":"Mrs","forename":"Sally","surname":"Smurf","email":null,"telNo":null}}}}
