### PR TITLE
CR-812_Telephone_Capture_Accepted

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.53</version>
+      <version>0.0.54</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/repository/CaseDataRepository.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/repository/CaseDataRepository.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.repository;
 
 import java.util.Optional;
+import java.util.UUID;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.model.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
@@ -16,7 +17,7 @@ public interface CaseDataRepository {
    * @throws CTPException undefined system error on storing case to repository
    * @throws DataStoreContentionException repository store operation failing
    */
-  void writeCachedCase(CachedCase newCase) throws CTPException, DataStoreContentionException;
+  void writeCachedCase(final CachedCase newCase) throws CTPException, DataStoreContentionException;
 
   /**
    * Read a Case for an address by Unique Property Reference Number
@@ -27,4 +28,13 @@ public interface CaseDataRepository {
    */
   Optional<CachedCase> readCachedCaseByUPRN(final UniquePropertyReferenceNumber uprn)
       throws CTPException;
+
+  /**
+   * Read a skeleton Case by Id
+   *
+   * @param caseId of case to read
+   * @return Optional containing case for Id if available
+   * @throws CTPException for error reading case
+   */
+  Optional<CachedCase> readCachedCaseById(final UUID caseId) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/repository/impl/CaseDataRepositoryImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/repository/impl/CaseDataRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -50,7 +51,8 @@ public class CaseDataRepositoryImpl implements CaseDataRepository {
       maxAttemptsExpression = "#{${cloud-storage.backoff-max-attempts}}",
       listeners = "ccRetryListener")
   @Override
-  public void writeCachedCase(CachedCase caze) throws CTPException, DataStoreContentionException {
+  public void writeCachedCase(final CachedCase caze)
+      throws CTPException, DataStoreContentionException {
     cloudDataStore.storeObject(caseSchema, caze.getId(), caze);
   }
 
@@ -71,5 +73,10 @@ public class CaseDataRepositoryImpl implements CaseDataRepository {
     } else {
       return Optional.ofNullable(results.get(0));
     }
+  }
+
+  @Override
+  public Optional<CachedCase> readCachedCaseById(final UUID caseId) throws CTPException {
+    return cloudDataStore.retrieveObject(CachedCase.class, caseSchema, caseId.toString());
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -767,6 +767,35 @@ public class CaseServiceImplTest {
     }
   }
 
+  @Test(expected = CTPException.class)
+  public void testLaunch_caseServiceNotFoundException_cachedCase() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
+        .when(caseServiceClient)
+        .getCaseById(UUID_0, false);
+    Mockito.when(dataRepo.readCachedCaseById(UUID_0)).thenReturn(Optional.of(new CachedCase()));
+    LaunchRequestDTO launchRequestDTO = CaseServiceFixture.createLaunchRequestDTO(false);
+    target.getLaunchURLForCaseId(UUID_0, launchRequestDTO);
+  }
+
+  @Test(expected = ResponseStatusException.class)
+  public void testLaunch_caseServiceNotFoundException_noCachedCase() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
+        .when(caseServiceClient)
+        .getCaseById(UUID_0, false);
+    Mockito.when(dataRepo.readCachedCaseById(UUID_0)).thenReturn(Optional.empty());
+    LaunchRequestDTO launchRequestDTO = CaseServiceFixture.createLaunchRequestDTO(true);
+    target.getLaunchURLForCaseId(UUID_0, launchRequestDTO);
+  }
+
+  @Test(expected = ResponseStatusException.class)
+  public void testLaunch_caseServiceResponseStatusException() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT))
+        .when(caseServiceClient)
+        .getCaseById(UUID_0, false);
+    LaunchRequestDTO launchRequestDTO = CaseServiceFixture.createLaunchRequestDTO(true);
+    target.getLaunchURLForCaseId(UUID_0, launchRequestDTO);
+  }
+
   @SneakyThrows
   private void assertThatInvalidLaunchComboIsRejected(CaseContainerDTO dto, String expectedMsg) {
     try {


### PR DESCRIPTION
 # Motivation and Context
Amendment to endpoint "cases/{caseId}/launch".  If RM Case Service does not return the case but a new skeleton case exists in the Contact Centre repository, i.e. a new skeleton case has been created by the Contact Centre for an address but the NewAddressReported event not actioned by RM, return HTTP status 202 Accepted - the request has been accepted but might or might not be acted upon.

# What has changed
CaseServiceImpl changed to throw CTPException with Fault.ACCEPTED_UNABLE_TO_PROCESS for required scenario.

# How to test?
Unit tests extended to cover required scenario. Has also been tested locally and will deploy to Dev.

