### PR TITLE
CR-813 Allow use of cached case for getCaseByCaseID

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/CaseService.java
@@ -17,7 +17,7 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.SMSFulfilmentR
 /** Service responsible for dealing with Cases */
 public interface CaseService {
 
-  CaseDTO getCaseById(final UUID caseId, CaseQueryRequestDTO requestParamsDTO);
+  CaseDTO getCaseById(final UUID caseId, CaseQueryRequestDTO requestParamsDTO) throws CTPException;
 
   /**
    * Return HH, CE and SPG cases but filter out any HI cases at address

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -339,8 +339,7 @@ public class CaseServiceImplTest {
   }
 
   @Test(expected = CTPException.class)
-  public void testFulfilmentRequestBySMS_caseSvcNotFoundResponse_noCachedCase_pmb()
-      throws Exception {
+  public void testFulfilmentRequestBySMS_caseSvcNotFoundResponse_noCachedCase() throws Exception {
     CaseContainerDTO caseData = casesFromCaseService().get(0);
     Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
         .when(caseServiceClient)
@@ -484,19 +483,6 @@ public class CaseServiceImplTest {
       assertEquals("Case is not suitable", e.getReason());
       assertEquals(HttpStatus.FORBIDDEN, e.getStatus());
     }
-  }
-
-  @Test(expected = CTPException.class)
-  public void testFulfilmentRequestBySMS_caseSvcNotFoundResponse_noCachedCase() throws Exception {
-    CaseContainerDTO caseData = casesFromCaseService().get(0);
-    Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
-        .when(caseServiceClient)
-        .getCaseById(eq(UUID_0), any());
-    Mockito.when(dataRepo.readCachedCaseById(eq(UUID_0))).thenReturn(Optional.empty());
-
-    SMSFulfilmentRequestDTO requestBodyDTOFixture = getSMSFulfilmentRequestDTO(caseData);
-
-    target.fulfilmentRequestBySMS(requestBodyDTOFixture);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -415,7 +415,7 @@ public class CaseServiceImplTest {
   }
 
   @Test
-  public void shouldGetSecureEstablishmentByCaseId() {
+  public void shouldGetSecureEstablishmentByCaseId() throws CTPException {
     CaseContainerDTO caseFromCaseService = casesFromCaseService().get(1);
     Mockito.when(caseServiceClient.getCaseById(eq(UUID_1), any())).thenReturn(caseFromCaseService);
 
@@ -425,7 +425,7 @@ public class CaseServiceImplTest {
   }
 
   @Test
-  public void testGetCaseByCaseId_householdIndividualCase() {
+  public void testGetCaseByCaseId_householdIndividualCase() throws CTPException {
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService = casesFromCaseService().get(0);
     caseFromCaseService.setCaseType("HI"); // Household Individual case


### PR DESCRIPTION
The getCaseByCaseID endpoint now attempts to return the case from the cache if not available from the case service. 
It calls down to existing code to actually call the case service and do the cache read.