### PR TITLE
CR-795_AIMS_epoch_query_string_parameter

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ctp.integration.contactcentresvc.client.addressindex;
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
 import javax.inject.Inject;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
@@ -40,6 +41,7 @@ public class AddressServiceClientServiceImpl {
     queryParams.add("input", input);
     queryParams.add("offset", Integer.toString(offset));
     queryParams.add("limit", Integer.toString(limit));
+    addEpoch(queryParams);
 
     // Ask Address Index to do an address search
     String path = appConfig.getAddressIndexSettings().getAddressQueryPath();
@@ -57,7 +59,6 @@ public class AddressServiceClientServiceImpl {
       PostcodeQueryRequestDTO postcodeQueryRequest) {
     log.debug("Delegating postcode search to the AddressIndex service");
 
-    String postcode = postcodeQueryRequest.getPostcode();
     int offset = postcodeQueryRequest.getOffset();
     int limit = postcodeQueryRequest.getLimit();
 
@@ -65,8 +66,10 @@ public class AddressServiceClientServiceImpl {
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     queryParams.add("offset", Integer.toString(offset));
     queryParams.add("limit", Integer.toString(limit));
+    addEpoch(queryParams);
 
     // Ask Address Index to do postcode search
+    String postcode = postcodeQueryRequest.getPostcode();
     String path = appConfig.getAddressIndexSettings().getPostcodeLookupPath();
     AddressIndexSearchResultsDTO addressIndexResponse =
         addressIndexClient.getResource(
@@ -85,6 +88,7 @@ public class AddressServiceClientServiceImpl {
     // Build map for query params
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     queryParams.add("addresstype", appConfig.getAddressIndexSettings().getAddressType());
+    addEpoch(queryParams);
 
     // Ask Address Index to do uprn search
     String path = appConfig.getAddressIndexSettings().getUprnLookupPath();
@@ -97,5 +101,13 @@ public class AddressServiceClientServiceImpl {
         .debug("UPRN query response received");
 
     return addressIndexResponse;
+  }
+
+  private MultiValueMap<String, String> addEpoch(MultiValueMap<String, String> queryParams) {
+    String epoch = appConfig.getAddressIndexSettings().getEpoch();
+    if (!StringUtils.isBlank(epoch)) {
+      queryParams.add("epoch", epoch);
+    }
+    return queryParams;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AddressIndexSettings.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AddressIndexSettings.java
@@ -9,5 +9,6 @@ public class AddressIndexSettings {
   private String postcodeLookupPath;
   private String uprnLookupPath;
   private String addressType;
+  private String epoch;
   private RestClientConfig restClientConfig;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -113,6 +113,7 @@ address-index-settings:
   postcode-lookup-path: /addresses/postcode/{postcode}
   uprn-lookup-path: /addresses/rh/uprn/{uprn}
   address-type: paf
+  epoch:
   rest-client-config:
     username:
     password:


### PR DESCRIPTION
# Motivation and Context
Add 'epoch' as a query string parameter to requests to Address Index, configured by environment variable.

# What has changed
Simple addition of "epoch"  in requests to Address Index from AddressServiceClientServiceImpl.

# How to test?
Unit tests amended to include epoch, test included without epoch set.

#Note
If required to query a particular Address Index dataset set the environment variable:
'ADDRESS_INDEX_SETTINGS_EPOCH={epoch required e.g. 72}'
The nomenclature of this environment variable is set by the application.yml group of settings to which it belongs. It is not quite consistent with those of RH UI e.g. 'ADDRESS_INDEX_EPOCH'.
