### PR TITLE
Cr 985 call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,12 +110,6 @@
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
-      <artifactId>event-publisher</artifactId>
-      <version>0.0.33</version>
-    </dependency>
-
-    <dependency>
-      <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>test-framework</artifactId>
       <version>0.0.14</version>
       <scope>test</scope>
@@ -124,7 +118,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.101</version>
+      <version>0.0.103</version>
     </dependency>
 
     <!--
@@ -141,14 +135,8 @@
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
-      <artifactId>census-int-case-api-client</artifactId>
-      <version>0.0.14</version>
-    </dependency>
-
-    <dependency>
-      <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>eq-launcher</artifactId>
-      <version>0.0.25</version>
+      <version>0.0.26-SNAPSHOT</version>
     </dependency>
 
     <!-- ONS END -->

--- a/pom.xml
+++ b/pom.xml
@@ -136,7 +136,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>eq-launcher</artifactId>
-      <version>0.0.26-SNAPSHOT</version>
+      <version>0.0.26</version>
     </dependency>
 
     <!-- ONS END -->

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -706,6 +706,7 @@ public class CaseServiceImpl implements CaseService {
     CollectionCaseCompact collectionCase = new CollectionCaseCompact(caseId);
     refusal.setCollectionCase(collectionCase);
     refusal.setAgentId(refusalRequest.getAgentId());
+    refusal.setCallId(refusalRequest.getCallId());
 
     // Populate contact
     Contact contact = new Contact();

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.java
@@ -13,10 +13,11 @@ import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -30,10 +31,12 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.ResponseDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 
 /** Contact Centre Data Endpoint Unit tests */
+@RunWith(MockitoJUnitRunner.class)
 public final class CaseEndpointRefusalTest {
 
   private static final String CASE_ID = "caseId";
   private static final String AGENT_ID = "agentId";
+  private static final String CALL_ID = "callId";
   private static final String TITLE = "title";
   private static final String NOTES = "notes";
   private static final String TEL_NO = "telNo";
@@ -60,15 +63,8 @@ public final class CaseEndpointRefusalTest {
   // UUID_STR must match the UUID in the test fixture
   private static final String UUID_STR = "3fa85f64-5717-4562-b3fc-2c963f66afa6";
 
-  /**
-   * Set up of tests
-   *
-   * @throws Exception exception thrown
-   */
   @Before
-  public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-
+  public void setUp() {
     this.mockMvc =
         MockMvcBuilders.standaloneSetup(caseEndpoint)
             .setHandlerExceptionResolvers(mockAdviceFor(RestExceptionHandler.class))
@@ -301,6 +297,16 @@ public final class CaseEndpointRefusalTest {
   @Test
   public void refusalAgentIdOk() throws Exception {
     assertOk(AGENT_ID, "12345");
+  }
+
+  @Test
+  public void refusalCallIdRequired() throws Exception {
+    assertBadRequest(CALL_ID, (String) null);
+  }
+
+  @Test
+  public void refusalCallIdOk() throws Exception {
+    assertOk(CALL_ID, "8989-NOW");
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
@@ -142,6 +142,7 @@ public abstract class EndpointSecurityTest {
     requestBody.setCaseId(caseId.toString());
     requestBody.setReason(Reason.HARD);
     requestBody.setAgentId("12345");
+    requestBody.setCallId("8989-NOW");
     requestBody.setDateTime(new Date());
 
     ResponseEntity<String> response =

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTest.java
@@ -141,6 +141,7 @@ public class CaseServiceImplTest {
   private static final boolean USE_CACHED_CASE = true;
   private static final boolean NO_CACHED_CASE = false;
 
+  private static final String A_CALL_ID = "8989-NOW";
   private static final String A_UPRN = "1234";
   private static final String AN_ESTAB_UPRN = "334111111111";
   private static final UniquePropertyReferenceNumber UPRN =
@@ -1234,6 +1235,7 @@ public class CaseServiceImplTest {
             .region(A_REGION)
             .reason(reason)
             .dateTime(dateTime)
+            .callId(A_CALL_ID)
             .build();
 
     // report the refusal
@@ -1267,6 +1269,7 @@ public class CaseServiceImplTest {
     RespondentRefusalDetails refusal = refusalEventCaptor.getValue();
     assertEquals("Description of refusal", refusal.getReport());
     assertEquals("123", refusal.getAgentId());
+    assertEquals(A_CALL_ID, refusal.getCallId());
     assertEquals(expectedEventCaseId, refusal.getCollectionCase().getId());
 
     verifyRefusalAddress(refusal, uprn);

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.json
@@ -1,6 +1,7 @@
 {
   "caseId": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
   "agentId": "12345",
+  "callId": "8989-NOW",
   "reason": "HARD",
   "title": "Mr",
   "forename": "Phil",


### PR DESCRIPTION
# Motivation and Context
A new **callId** attribute is required for the refusal details

# What has changed
The refusal endpoint DTO passes in the callId which is copied to the refusal event object.

