### PR TITLE
Cr 992 remove hand delivery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.115-SNAPSHOT</version>
+      <version>0.0.115</version>
     </dependency>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.112</version>
+      <version>0.0.115-SNAPSHOT</version>
     </dependency>
 
     <!--

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -82,6 +82,8 @@ public class CaseServiceImpl implements CaseService {
       "All Northern Ireland calls from CE Managers are to be escalated to the NI management team.";
   private static final String UNIT_LAUNCH_ERR_MSG =
       "A CE Manager form can only be launched against an establishment address not a UNIT.";
+  private static final List<DeliveryChannel> ALL_DELIVERY_CHANNELS =
+      List.of(DeliveryChannel.POST, DeliveryChannel.SMS);
 
   private static final String SCOTLAND_COUNTRY_CODE = "S";
 
@@ -254,8 +256,7 @@ public class CaseServiceImpl implements CaseService {
 
   private CaseDTO mapCaseContainerDTO(CaseContainerDTO caseDetails) {
     CaseDTO caseServiceResponse = caseDTOMapper.map(caseDetails, CaseDTO.class);
-    caseServiceResponse.setAllowedDeliveryChannels(
-        calculateAllowedDeliveryChannels(caseServiceResponse));
+    caseServiceResponse.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
     caseServiceResponse.setEstabType(EstabType.forCode(caseServiceResponse.getEstabDescription()));
 
     return caseServiceResponse;
@@ -265,33 +266,12 @@ public class CaseServiceImpl implements CaseService {
     List<CaseDTO> caseServiceListResponse = caseDTOMapper.mapAsList(casesToReturn, CaseDTO.class);
 
     for (CaseDTO caseServiceResponse : caseServiceListResponse) {
-      caseServiceResponse.setAllowedDeliveryChannels(
-          calculateAllowedDeliveryChannels(caseServiceResponse));
+      caseServiceResponse.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
       caseServiceResponse.setEstabType(
           EstabType.forCode(caseServiceResponse.getEstabDescription()));
     }
 
     return caseServiceListResponse;
-  }
-
-  private List<DeliveryChannel> calculateAllowedDeliveryChannels(CaseDTO caseServiceResponse) {
-
-    List<DeliveryChannel> dcList = null;
-
-    if (caseServiceResponse.isHandDelivery()
-        && caseServiceResponse.getCaseType().equals(CaseType.SPG.name())) {
-      log.with(caseServiceResponse.getId())
-          .debug(
-              "Calculating allowed delivery channel list as [SMS] because handDelivery=true "
-                  + "and caseType=SPG");
-      dcList = Arrays.asList(DeliveryChannel.SMS);
-    } else {
-      log.with(caseServiceResponse.getId())
-          .debug("Calculating allowed delivery channel list as [POST, SMS]");
-      dcList = Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    }
-
-    return dcList;
   }
 
   @Override
@@ -663,11 +643,6 @@ public class CaseServiceImpl implements CaseService {
     Product product = findProduct(fulfilmentCode, deliveryChannel, region);
 
     if (deliveryChannel == Product.DeliveryChannel.POST) {
-      if (caze.isHandDelivery()) {
-        log.info("Postal fulfilments cannot be delivered to this respondent");
-        throw new CTPException(
-            Fault.BAD_REQUEST, "Postal fulfilments cannot be delivered to this respondent");
-      }
       if (product.getIndividual()) {
         if (StringUtils.isBlank(contact.getTitle())
             || StringUtils.isBlank(contact.getForename())

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapperTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapperTest.java
@@ -38,7 +38,6 @@ public class CCSvcBeanMapperTest {
     assertEquals(source.getEstabUprn(), String.valueOf(destination.getEstabUprn().getValue()));
     assertEquals(source.getCreatedDateTime(), destination.getCreatedDateTime());
     assertEquals(source.getLastUpdated(), destination.getLastUpdated());
-    assertEquals(source.isHandDelivery(), destination.isHandDelivery());
     for (int i = 0; i < source.getCaseEvents().size(); i++) {
       EventDTO sourceEvent = source.getCaseEvents().get(i);
       CaseEventDTO destinationEvent = destination.getCaseEvents().get(i);

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplFulfilmentTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplFulfilmentTest.java
@@ -132,42 +132,6 @@ public class CaseServiceImplFulfilmentTest extends CaseServiceImplTestBase {
     }
   }
 
-  @Test
-  public void testFulfilmentRequestByPostFailure_handDeliveryOnly() throws Exception {
-
-    Mockito.clearInvocations(eventPublisher);
-
-    // Build results to be returned from search
-    CaseContainerDTO caseFromCaseService = casesFromCaseService().get(0);
-    caseFromCaseService.setCaseType("SPG");
-    caseFromCaseService.setHandDelivery(true);
-    Mockito.when(caseServiceClient.getCaseById(eq(UUID_0), any())).thenReturn(caseFromCaseService);
-
-    PostalFulfilmentRequestDTO requestBodyDTOFixture =
-        getPostalFulfilmentRequestDTO(UUID_0, "Mrs", "Sally", "Smurf");
-
-    Product expectedSearchCriteria =
-        getExpectedSearchCriteria(
-            Product.Region.E,
-            requestBodyDTOFixture.getFulfilmentCode(),
-            Product.DeliveryChannel.POST);
-
-    Product productFoundFixture =
-        getProductFoundFixture(
-            Arrays.asList(Product.CaseType.SPG), Product.DeliveryChannel.POST, false);
-    Mockito.when(productReference.searchProducts(eq(expectedSearchCriteria)))
-        .thenReturn(new ArrayList<Product>(List.of(productFoundFixture)));
-
-    try {
-      // execution - call the unit under test
-      target.fulfilmentRequestByPost(requestBodyDTOFixture);
-      fail();
-    } catch (CTPException e) {
-      assertEquals("Postal fulfilments cannot be delivered to this respondent", e.getMessage());
-      assertEquals("BAD_REQUEST", e.getFault().name());
-    }
-  }
-
   @Test(expected = CTPException.class)
   public void testFulfilmentRequestByPost_caseSvcNotFoundResponse_noCachedCase() throws Exception {
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
@@ -11,10 +11,10 @@ import static org.mockito.Mockito.never;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_0;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_1;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.junit.Before;
@@ -35,15 +35,11 @@ import uk.gov.ons.ctp.integration.contactcentresvc.config.CaseServiceSettings;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseQueryRequestDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 
 /** Unit Test {@link CaseService#getCaseById(UUID, CaseQueryRequestDTO) getCaseById}. */
 @RunWith(MockitoJUnitRunner.class)
 public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
-  private static final boolean HAND_DELIVERY_TRUE = true;
-  private static final boolean HAND_DELIVERY_FALSE = false;
-
   private static final boolean CASE_EVENTS_TRUE = true;
   private static final boolean CASE_EVENTS_FALSE = false;
 
@@ -63,97 +59,32 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
 
   @Test
   public void testGetHouseholdCaseByCaseId_withCaseDetails() {
-    List<DeliveryChannel> expectedDeliveryChannels =
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.HH,
-        HAND_DELIVERY_FALSE,
-        CASE_EVENTS_TRUE,
-        NO_CACHED_CASE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.HH, CASE_EVENTS_TRUE, NO_CACHED_CASE);
   }
 
   @Test
   public void testGetHouseholdCaseByCaseId_withNoCaseDetails() {
-    List<DeliveryChannel> expectedDeliveryChannels =
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.HH,
-        HAND_DELIVERY_FALSE,
-        CASE_EVENTS_FALSE,
-        NO_CACHED_CASE,
-        expectedDeliveryChannels);
-  }
-
-  @Test
-  public void testGetCaseByCaseId_caseHHhandDeliveryTrue() {
-    List<DeliveryChannel> expectedDeliveryChannels =
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.HH,
-        HAND_DELIVERY_TRUE,
-        CASE_EVENTS_FALSE,
-        NO_CACHED_CASE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.HH, CASE_EVENTS_FALSE, NO_CACHED_CASE);
   }
 
   @Test
   public void testGetCommunalCaseByCaseId_withCaseDetails() {
-    List<DeliveryChannel> expectedDeliveryChannels =
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.CE,
-        HAND_DELIVERY_TRUE,
-        CASE_EVENTS_TRUE,
-        NO_CACHED_CASE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.CE, CASE_EVENTS_TRUE, NO_CACHED_CASE);
   }
 
   @Test
   public void testGetCommunalCaseByCaseId_withNoCaseDetails() {
-    List<DeliveryChannel> expectedDeliveryChannels =
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.CE,
-        HAND_DELIVERY_TRUE,
-        CASE_EVENTS_FALSE,
-        NO_CACHED_CASE,
-        expectedDeliveryChannels);
+    doTestGetCaseByCaseId(CaseType.CE, CASE_EVENTS_FALSE, NO_CACHED_CASE);
   }
 
   @Test
-  public void testGetCaseByCaseId_caseSPGhandDeliveryTrue() {
-    List<DeliveryChannel> expectedDeliveryChannels = Arrays.asList(DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.SPG,
-        HAND_DELIVERY_TRUE,
-        CASE_EVENTS_FALSE,
-        NO_CACHED_CASE,
-        expectedDeliveryChannels);
+  public void testGetCaseByCaseId_caseSPG() {
+    doTestGetCaseByCaseId(CaseType.SPG, CASE_EVENTS_FALSE, NO_CACHED_CASE);
   }
 
   @Test
-  public void testGetCaseByCaseId_caseSPGhandDeliveryFalse() {
-    List<DeliveryChannel> expectedDeliveryChannels =
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.SPG,
-        HAND_DELIVERY_FALSE,
-        CASE_EVENTS_FALSE,
-        NO_CACHED_CASE,
-        expectedDeliveryChannels);
-  }
-
-  @Test
-  public void testGetCaseByCaseId_caseSPGhandDeliveryFalse_fromCache() {
-    List<DeliveryChannel> expectedDeliveryChannels =
-        Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS);
-    doTestGetCaseByCaseId(
-        CaseType.SPG,
-        HAND_DELIVERY_FALSE,
-        CASE_EVENTS_FALSE,
-        USE_CACHED_CASE,
-        expectedDeliveryChannels);
+  public void testGetCaseByCaseId_caseSPG_fromCache() {
+    doTestGetCaseByCaseId(CaseType.SPG, CASE_EVENTS_FALSE, USE_CACHED_CASE);
   }
 
   @Test
@@ -184,16 +115,10 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
   }
 
   @SneakyThrows
-  private void doTestGetCaseByCaseId(
-      CaseType caseType,
-      boolean handDelivery,
-      boolean caseEvents,
-      boolean cached,
-      List<DeliveryChannel> expectedAllowedDeliveryChannels) {
+  private void doTestGetCaseByCaseId(CaseType caseType, boolean caseEvents, boolean cached) {
     // Build results to be returned from search
     CaseContainerDTO caseFromCaseService = casesFromCaseService().get(0);
     caseFromCaseService.setCaseType(caseType.name());
-    caseFromCaseService.setHandDelivery(handDelivery);
     CaseDTO expectedCaseResult;
 
     if (cached) {
@@ -207,14 +132,12 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
           .thenReturn(Optional.of(caseFromRepository));
 
       CaseContainerDTO expectedCase = mapperFacade.map(caseFromRepository, CaseContainerDTO.class);
-      expectedCaseResult =
-          createExpectedCaseDTO(expectedCase, caseEvents, expectedAllowedDeliveryChannels);
+      expectedCaseResult = createExpectedCaseDTO(expectedCase, caseEvents);
 
     } else {
       Mockito.when(caseServiceClient.getCaseById(eq(UUID_0), any()))
           .thenReturn(caseFromCaseService);
-      expectedCaseResult =
-          createExpectedCaseDTO(caseFromCaseService, caseEvents, expectedAllowedDeliveryChannels);
+      expectedCaseResult = createExpectedCaseDTO(caseFromCaseService, caseEvents);
     }
 
     // Run the request
@@ -229,10 +152,7 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
     return uprn == null ? null : new UniquePropertyReferenceNumber(uprn);
   }
 
-  private CaseDTO createExpectedCaseDTO(
-      CaseContainerDTO caseFromCaseService,
-      boolean caseEvents,
-      List<DeliveryChannel> expectedAllowedDeliveryChannels) {
+  private CaseDTO createExpectedCaseDTO(CaseContainerDTO caseFromCaseService, boolean caseEvents) {
 
     CaseDTO expectedCaseResult =
         CaseDTO.builder()
@@ -241,7 +161,7 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
             .caseType(caseFromCaseService.getCaseType())
             .estabType(EstabType.forCode(caseFromCaseService.getEstabType()))
             .estabDescription(caseFromCaseService.getEstabType())
-            .allowedDeliveryChannels(expectedAllowedDeliveryChannels)
+            .allowedDeliveryChannels(ALL_DELIVERY_CHANNELS)
             .createdDateTime(caseFromCaseService.getCreatedDateTime())
             .lastUpdated(caseFromCaseService.getLastUpdated())
             .addressLine1(caseFromCaseService.getAddressLine1())
@@ -254,7 +174,6 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
             .ceOrgName(caseFromCaseService.getOrganisationName())
             .uprn(createUprn(caseFromCaseService.getUprn()))
             .estabUprn(createUprn(caseFromCaseService.getEstabUprn()))
-            .handDelivery(caseFromCaseService.isHandDelivery())
             .secureEstablishment(caseFromCaseService.isSecureEstablishment())
             .build();
     if (caseEvents) {
@@ -287,7 +206,6 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
     assertEquals(expectedCaseResult.getCeOrgName(), results.getCeOrgName());
     assertEquals(
         expectedCaseResult.getAllowedDeliveryChannels(), results.getAllowedDeliveryChannels());
-    assertEquals(expectedCaseResult.isHandDelivery(), results.isHandDelivery());
 
     if (caseEventsExpected) {
       // Note that the test data contains 3 events, but the 'X11' event is filtered out as it is not

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
@@ -272,27 +272,18 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     List<CaseDTO> results = target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(caseEvents));
     assertEquals(1, results.size());
 
-    CaseDTO expectedCaseResult =
-        createExpectedCaseDTO(
-            caseFromCaseService.get(1),
-            caseEvents,
-            Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+    CaseDTO expectedCaseResult = createExpectedCaseDTO(caseFromCaseService.get(1), caseEvents);
     verifyCase(results.get(0), expectedCaseResult, caseEvents);
   }
 
   @Test
-  public void testGetCaseByUprn_caseSPGhandDeliveryTrue() throws CTPException {
-    doTestGetCasesByUprn("SPG", true, Arrays.asList(DeliveryChannel.SMS));
+  public void testGetCaseByUprn_caseSPG() throws CTPException {
+    doTestGetCasesByUprn("SPG");
   }
 
   @Test
-  public void testGetCaseByUprn_caseHHhandDeliveryTrue() throws CTPException {
-    doTestGetCasesByUprn("HH", true, Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
-  }
-
-  @Test
-  public void testGetCaseByUprn_caseSPGhandDeliveryFalse() throws CTPException {
-    doTestGetCasesByUprn("SPG", false, Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+  public void testGetCaseByUprn_caseHH() throws CTPException {
+    doTestGetCasesByUprn("HH");
   }
 
   @Test
@@ -307,14 +298,11 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     assertEquals(new UniquePropertyReferenceNumber(AN_ESTAB_UPRN), results.get(1).getEstabUprn());
   }
 
-  private void doTestGetCasesByUprn(
-      String caseType, boolean handDelivery, List<DeliveryChannel> expectedDeliveryChannels)
-      throws CTPException {
+  private void doTestGetCasesByUprn(String caseType) throws CTPException {
     UniquePropertyReferenceNumber uprn = new UniquePropertyReferenceNumber(334999999999L);
 
     List<CaseContainerDTO> caseFromCaseService = casesFromCaseService();
     caseFromCaseService.get(0).setCaseType(caseType);
-    caseFromCaseService.get(0).setHandDelivery(handDelivery);
     Mockito.when(caseServiceClient.getCaseByUprn(eq(uprn.getValue()), any()))
         .thenReturn(caseFromCaseService);
 
@@ -323,8 +311,7 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     List<CaseDTO> results = target.getCaseByUPRN(uprn, new CaseQueryRequestDTO(caseEvents));
     assertEquals(2, results.size());
 
-    CaseDTO expectedCaseResult =
-        createExpectedCaseDTO(caseFromCaseService.get(0), caseEvents, expectedDeliveryChannels);
+    CaseDTO expectedCaseResult = createExpectedCaseDTO(caseFromCaseService.get(0), caseEvents);
     verifyCase(results.get(0), expectedCaseResult, caseEvents);
   }
 
@@ -342,18 +329,10 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     List<CaseDTO> results = target.getCaseByUPRN(uprn, requestParams);
 
     // Verify response
-    CaseDTO expectedCaseResult0 =
-        createExpectedCaseDTO(
-            caseFromCaseService.get(0),
-            caseEvents,
-            Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+    CaseDTO expectedCaseResult0 = createExpectedCaseDTO(caseFromCaseService.get(0), caseEvents);
     verifyCase(results.get(0), expectedCaseResult0, caseEvents);
 
-    CaseDTO expectedCaseResult1 =
-        createExpectedCaseDTO(
-            caseFromCaseService.get(1),
-            caseEvents,
-            Arrays.asList(DeliveryChannel.POST, DeliveryChannel.SMS));
+    CaseDTO expectedCaseResult1 = createExpectedCaseDTO(caseFromCaseService.get(1), caseEvents);
     verifyCase(results.get(1), expectedCaseResult1, caseEvents);
   }
 
@@ -361,10 +340,7 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     return uprn == null ? null : new UniquePropertyReferenceNumber(uprn);
   }
 
-  private CaseDTO createExpectedCaseDTO(
-      CaseContainerDTO caseFromCaseService,
-      boolean caseEvents,
-      List<DeliveryChannel> expectedAllowedDeliveryChannels) {
+  private CaseDTO createExpectedCaseDTO(CaseContainerDTO caseFromCaseService, boolean caseEvents) {
 
     CaseDTO expectedCaseResult =
         CaseDTO.builder()
@@ -373,7 +349,7 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
             .caseType(caseFromCaseService.getCaseType())
             .estabType(EstabType.forCode(caseFromCaseService.getEstabType()))
             .estabDescription(caseFromCaseService.getEstabType())
-            .allowedDeliveryChannels(expectedAllowedDeliveryChannels)
+            .allowedDeliveryChannels(ALL_DELIVERY_CHANNELS)
             .createdDateTime(caseFromCaseService.getCreatedDateTime())
             .lastUpdated(caseFromCaseService.getLastUpdated())
             .addressLine1(caseFromCaseService.getAddressLine1())
@@ -386,7 +362,6 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
             .ceOrgName(caseFromCaseService.getOrganisationName())
             .uprn(createUprn(caseFromCaseService.getUprn()))
             .estabUprn(createUprn(caseFromCaseService.getEstabUprn()))
-            .handDelivery(caseFromCaseService.isHandDelivery())
             .secureEstablishment(caseFromCaseService.isSecureEstablishment())
             .build();
     if (caseEvents) {
@@ -419,7 +394,6 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     assertEquals(expectedCaseResult.getCeOrgName(), results.getCeOrgName());
     assertEquals(
         expectedCaseResult.getAllowedDeliveryChannels(), results.getAllowedDeliveryChannels());
-    assertEquals(expectedCaseResult.isHandDelivery(), results.isHandDelivery());
 
     if (caseEventsExpected) {
       // Note that the test data contains 3 events, but the 'X11' event is filtered out as it is not

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.List;
 import ma.glasnost.orika.MapperFacade;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -16,6 +17,7 @@ import uk.gov.ons.ctp.integration.common.product.ProductReference;
 import uk.gov.ons.ctp.integration.contactcentresvc.CCSvcBeanMapper;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.AppConfig;
 import uk.gov.ons.ctp.integration.contactcentresvc.repository.CaseDataRepository;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.AddressService;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchService;
@@ -37,6 +39,9 @@ public abstract class CaseServiceImplTestBase {
   @Mock CaseDataRepository dataRepo;
 
   @Mock AddressService addressSvc;
+
+  static final List<DeliveryChannel> ALL_DELIVERY_CHANNELS =
+      List.of(DeliveryChannel.POST, DeliveryChannel.SMS);
 
   @InjectMocks CaseService target = new CaseServiceImpl();
 


### PR DESCRIPTION
# Motivation and Context
CR-992 requires that the handDelivery attribute from RM plays no part in our processing in CCsvc, including not determining the allowed delivery channels returned for a case, and not preventing any fulfilment operations.

# What has changed
- allowedDeliveryChannels are always SMS and POST
- fulfilment by POST now no longer returns a 400 when handDelivery flag is set 

# What has NOT changed
- The CaseDTO has not changed. @philwhiles  requested that the handDelivery attribute remains despite us not using it.

# How to test?
- usual unit tests
- postman to endpoints, check allowedDeliveryChannels
- postman for fulfilment by POST will not return 400 for handDelivery case.
- note that CC cucumber had no tests that checked the allowed Delivery Channels were anything other than all channels, so there are no specific tests there.

