### PR TITLE
CR-1047 Extend UPRN validation to allow 13 digits

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,7 +106,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.61</version>
+      <version>0.0.62</version>
     </dependency>
 
     <dependency>
@@ -118,14 +118,14 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>test-framework</artifactId>
-      <version>0.0.15</version>
+      <version>0.0.16</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.115</version>
+      <version>0.0.118</version>
     </dependency>
 
     <!--

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.java
@@ -168,7 +168,7 @@ public final class CaseEndpointRefusalTest {
 
   @Test
   public void refusalUPRNTooLong() throws Exception {
-    assertBadRequest(UPRN, "1234567890123");
+    assertBadRequest(UPRN, "12345678901234");
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
UPRNs generated for skeleton cases by RM have an additional leading digit, needing to allow for 13 digits.

# What has changed
POM dependencies changed to include new UniquePropertyReferenceNumber allowing for 13 digits.

# How to test?
CaseEndPointRefusalTest Unit Test changed to use 14 digit UPRN to illicit BadRequest response.
Contact centre cucumber tests updated and run against this image in census-integration-dev. 

# Note
Please release with contact centre cucumber update.

# Links
Framework: https://github.com/ONSdigital/census-int-common-service/pull/44
Contact centre service api: https://github.com/ONSdigital/census-contact-centre-service-api/pull/53
Contact centre cucumber: https://github.com/ONSdigital/census-contact-centre-cucumber/pull/47
