### PR TITLE
CR-1068 Invalidate endpoint looking in cache if not found by RM

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -499,8 +499,8 @@ public class CaseServiceImpl implements CaseService {
   }
 
   // will throw exception if case does not exist.
-  private void verifyCaseExists(UUID caseId) {
-    caseServiceClient.getCaseById(caseId, false);
+  private void verifyCaseExists(UUID caseId) throws CTPException {
+    retrieveCaseById(caseId, false);
   }
 
   @Override

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplCaseInvalidateTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplCaseInvalidateTest.java
@@ -2,11 +2,13 @@ package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Optional;
 import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
@@ -16,11 +18,14 @@ import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
 import uk.gov.ons.ctp.common.event.EventPublisher.Source;
 import uk.gov.ons.ctp.common.event.model.AddressNotValid;
 import uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture;
+import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseStatus;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.InvalidateCaseRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.ResponseDTO;
@@ -39,7 +44,9 @@ public class CaseServiceImplCaseInvalidateTest extends CaseServiceImplTestBase {
   private void checkInvalidateCaseForStatus(CaseStatus status) {
     InvalidateCaseRequestDTO dto = CaseServiceFixture.createInvalidateCaseRequestDTO();
     dto.setStatus(status);
+
     ResponseDTO response = target.invalidateCase(dto);
+
     assertEquals(dto.getCaseId().toString(), response.getId());
     assertNotNull(response.getDateTime());
 
@@ -98,10 +105,22 @@ public class CaseServiceImplCaseInvalidateTest extends CaseServiceImplTestBase {
     checkInvalidateCaseForStatus(CaseStatus.DOES_NOT_EXIST);
   }
 
-  @Test(expected = ResponseStatusException.class)
-  public void shouldRejectCaseNotFound() throws Exception {
+  @Test
+  public void shouldRejectCaseNotFoundInRMOrCache() throws Exception {
     when(caseServiceClient.getCaseById(any(), any()))
-        .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND));
+        .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND)); // Not in RM
+    when(dataRepo.readCachedCaseById(any())).thenReturn(Optional.empty()); // Not in cache either
+    InvalidateCaseRequestDTO dto = CaseServiceFixture.createInvalidateCaseRequestDTO();
+    CTPException exception = assertThrows(CTPException.class, () -> target.invalidateCase(dto));
+    assertEquals(Fault.RESOURCE_NOT_FOUND, exception.getFault());
+  }
+
+  @Test
+  public void shouldInvalidateCaseWhenCaseOnlyInCache() throws Exception {
+    when(caseServiceClient.getCaseById(any(), any()))
+        .thenThrow(new ResponseStatusException(HttpStatus.NOT_FOUND)); // Not in RM
+    when(dataRepo.readCachedCaseById(any()))
+        .thenReturn(Optional.of(new CachedCase())); // It's in cache
     InvalidateCaseRequestDTO dto = CaseServiceFixture.createInvalidateCaseRequestDTO();
     target.invalidateCase(dto);
   }


### PR DESCRIPTION
Invalidate endpoint now looks for case in cache if not in RM.
Test cases extended.