### PR TITLE
Cr 1067 cached case failing due to empty events

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/cloud/CachedCase.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/cloud/CachedCase.java
@@ -1,11 +1,13 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.cloud;
 
 import java.util.Date;
+import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import uk.gov.ons.ctp.common.domain.CaseType;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
 
 @Data
 @Builder
@@ -40,4 +42,6 @@ public class CachedCase {
   private String region;
 
   private String ceOrgName;
+  
+  private List<CaseEventDTO> caseEvents;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/cloud/CachedCase.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/cloud/CachedCase.java
@@ -42,6 +42,6 @@ public class CachedCase {
   private String region;
 
   private String ceOrgName;
-  
+
   private List<CaseEventDTO> caseEvents;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -188,6 +188,7 @@ public class CaseServiceImpl implements CaseService {
     cachedCase.setEstabType(caseRequestDTO.getEstabType().getCode());
     cachedCase.setAddressType(addressType);
     cachedCase.setCreatedDateTime(DateTimeUtil.nowUTC());
+    cachedCase.setCaseEvents(new ArrayList<CaseEventDTO>());
 
     dataRepo.writeCachedCase(cachedCase);
 
@@ -364,6 +365,7 @@ public class CaseServiceImpl implements CaseService {
     cachedCase.setAddressLine2(modifyRequestDTO.getAddressLine2());
     cachedCase.setAddressLine3(modifyRequestDTO.getAddressLine3());
     cachedCase.setCeOrgName(modifyRequestDTO.getCeOrgName());
+    cachedCase.setCaseEvents(new ArrayList<CaseEventDTO>());
     dataRepo.writeCachedCase(cachedCase);
   }
 
@@ -982,7 +984,7 @@ public class CaseServiceImpl implements CaseService {
     cachedCase.setId(newCaseId.toString());
     cachedCase.setCreatedDateTime(DateTimeUtil.nowUTC());
     cachedCase.setCaseEvents(new ArrayList<CaseEventDTO>());
-    
+
     publishNewAddressReportedEvent(newCaseId, cachedCase.getCaseType(), 0, address);
 
     dataRepo.writeCachedCase(cachedCase);

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -829,7 +829,7 @@ public class CaseServiceImpl implements CaseService {
         log.with("caseId", caseId).debug("Case Id Not Found calling Case Service");
         Optional<CachedCase> cachedCase = dataRepo.readCachedCaseById(caseId);
         if (cachedCase.isPresent()) {
-          log.with("caseId", caseId).debug("Using stored case details");
+          log.with("caseId", caseId).info("Using stored case details");
           caze = caseDTOMapper.map(cachedCase.get(), CaseContainerDTO.class);
         } else {
           log.with("caseId", caseId).warn("Request for case Not Found");

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -981,7 +981,8 @@ public class CaseServiceImpl implements CaseService {
     UUID newCaseId = UUID.randomUUID();
     cachedCase.setId(newCaseId.toString());
     cachedCase.setCreatedDateTime(DateTimeUtil.nowUTC());
-
+    cachedCase.setCaseEvents(new ArrayList<CaseEventDTO>());
+    
     publishNewAddressReportedEvent(newCaseId, cachedCase.getCaseType(), 0, address);
 
     dataRepo.writeCachedCase(cachedCase);

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplCreateCaseForNewAddressTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplCreateCaseForNewAddressTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.times;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
 import org.junit.Before;
@@ -26,6 +27,7 @@ import uk.gov.ons.ctp.common.event.model.CollectionCaseNewAddress;
 import uk.gov.ons.ctp.common.event.model.NewAddress;
 import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.NewCaseRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
@@ -133,6 +135,7 @@ public class CaseServiceImplCreateCaseForNewAddressTest extends CaseServiceImplT
     String caseTypeName = caseRequestDTO.getCaseType().name();
     expectedCase.setAddressType(expectedAddressType);
     expectedCase.setEstabType(caseRequestDTO.getEstabType().getCode());
+    expectedCase.setCaseEvents(new ArrayList<CaseEventDTO>());
     assertEquals(expectedCase, storedCase);
 
     // Verify the NewAddressEvent

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
@@ -88,6 +88,11 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
   }
 
   @Test
+  public void testGetCaseByCaseId_caseSPG_fromCacheWithEvents() {
+    doTestGetCaseByCaseId(CaseType.SPG, CASE_EVENTS_TRUE, USE_CACHED_CASE);
+  }
+
+  @Test
   public void shouldGetSecureEstablishmentByCaseId() throws CTPException {
     CaseContainerDTO caseFromCaseService = casesFromCaseService().get(1);
     Mockito.when(caseServiceClient.getCaseById(eq(UUID_1), any())).thenReturn(caseFromCaseService);

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
@@ -149,7 +149,7 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
     CaseQueryRequestDTO requestParams = new CaseQueryRequestDTO(caseEvents);
     CaseDTO results = target.getCaseById(UUID_0, requestParams);
 
-    verifyCase(results, expectedCaseResult, caseEvents);
+    verifyCase(results, expectedCaseResult, caseEvents, cached);
     assertEquals(asMillis("2019-05-14T16:11:41.343+01:00"), results.getCreatedDateTime().getTime());
   }
 
@@ -201,7 +201,8 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
   }
 
   @SneakyThrows
-  private void verifyCase(CaseDTO results, CaseDTO expectedCaseResult, boolean caseEventsExpected) {
+  private void verifyCase(
+      CaseDTO results, CaseDTO expectedCaseResult, boolean caseEventsExpected, boolean cached) {
     assertEquals(expectedCaseResult.getId(), results.getId());
     assertEquals(expectedCaseResult.getCaseRef(), results.getCaseRef());
     assertEquals(expectedCaseResult.getCaseType(), results.getCaseType());
@@ -209,7 +210,10 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
     assertEquals(
         expectedCaseResult.getAllowedDeliveryChannels(), results.getAllowedDeliveryChannels());
 
-    if (caseEventsExpected) {
+    if (caseEventsExpected && cached) {
+      // Cached case doesn't have any events
+      assertTrue(results.getCaseEvents().isEmpty());
+    } else if (caseEventsExpected) {
       // Note that the test data contains 3 events, but the 'X11' event is filtered out as it is not
       // on the whitelist
       assertEquals(2, results.getCaseEvents().size());

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
@@ -462,15 +462,16 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
   }
 
   private String createFormattedAddress(AddressIndexAddressCompositeDTO expectedAddress) {
-    ArrayList<String> elements = new ArrayList<>();
-    elements.add(expectedAddress.getAddressLine1());
-    elements.add(expectedAddress.getAddressLine2());
-    elements.add(expectedAddress.getAddressLine3());
-    elements.add(expectedAddress.getTownName());
-    elements.add(expectedAddress.getPostcode());
+    String[] addressElements =
+        new String[] {
+          expectedAddress.getAddressLine1(),
+          expectedAddress.getAddressLine2(),
+          expectedAddress.getAddressLine3(),
+          expectedAddress.getTownName(),
+          expectedAddress.getPostcode()
+        };
 
-    return elements
-        .stream()
+    return Arrays.stream(addressElements)
         .filter(e -> e != null)
         .filter(e -> !e.isEmpty())
         .collect(Collectors.joining(", "));

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
@@ -447,7 +447,7 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
       CachedCase actualCapturedCase) {
     assertEquals(expectedId.toString(), actualCapturedCase.getId());
     assertEquals(expectedAddress.getUprn(), actualCapturedCase.getUprn());
-    assertEquals(createFormattedAddress(expectedAddress), actualCapturedCase.getFormattedAddress());
+    assertEquals(expectedAddress.getFormattedAddress(), actualCapturedCase.getFormattedAddress());
     assertEquals(expectedAddress.getAddressLine1(), actualCapturedCase.getAddressLine1());
     assertEquals(expectedAddress.getAddressLine2(), actualCapturedCase.getAddressLine2());
     assertEquals(expectedAddress.getAddressLine3(), actualCapturedCase.getAddressLine3());
@@ -459,22 +459,6 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     assertEquals(expectedAddress.getCountryCode(), actualCapturedCase.getRegion());
     assertEquals(expectedAddress.getOrganisationName(), actualCapturedCase.getCeOrgName());
     assertEquals(0, actualCapturedCase.getCaseEvents().size());
-  }
-
-  private String createFormattedAddress(AddressIndexAddressCompositeDTO expectedAddress) {
-    String[] addressElements =
-        new String[] {
-          expectedAddress.getAddressLine1(),
-          expectedAddress.getAddressLine2(),
-          expectedAddress.getAddressLine3(),
-          expectedAddress.getTownName(),
-          expectedAddress.getPostcode()
-        };
-
-    return Arrays.stream(addressElements)
-        .filter(e -> e != null)
-        .filter(e -> !e.isEmpty())
-        .collect(Collectors.joining(", "));
   }
 
   private void verifyCaseDTOContent(

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -425,8 +426,8 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     ArgumentCaptor<CachedCase> cachedCaseCaptor = ArgumentCaptor.forClass(CachedCase.class);
     Mockito.verify(dataRepo, times(1)).writeCachedCase(cachedCaseCaptor.capture());
     CachedCase capturedCase = cachedCaseCaptor.getValue();
-    verifyCachedCaseContent(address, result.getId(), capturedCase);
-    
+    verifyCachedCaseContent(address, result.getId(), CaseType.HH, capturedCase);
+
     // Verify response
     CachedCase cachedCase = mapperFacade.map(address, CachedCase.class);
     cachedCase.setId(result.getId().toString());
@@ -439,7 +440,10 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
         address.getCensusAddressType(), address.getCensusEstabType(), newAddress);
   }
 
-  private void verifyCachedCaseContent(AddressIndexAddressCompositeDTO expectedAddress, UUID expectedId,
+  private void verifyCachedCaseContent(
+      AddressIndexAddressCompositeDTO expectedAddress,
+      UUID expectedId,
+      CaseType expectedCaseType,
       CachedCase actualCapturedCase) {
     assertEquals(expectedId.toString(), actualCapturedCase.getId());
     assertEquals(expectedAddress.getUprn(), actualCapturedCase.getUprn());
@@ -449,13 +453,13 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     assertEquals(expectedAddress.getAddressLine3(), actualCapturedCase.getAddressLine3());
     assertEquals(expectedAddress.getTownName(), actualCapturedCase.getTownName());
     assertEquals(expectedAddress.getPostcode(), actualCapturedCase.getPostcode());
-    assertEquals("HH", actualCapturedCase.getAddressType());
-    assertEquals(CaseType.HH, actualCapturedCase.getCaseType());
+    assertEquals(expectedAddress.getCensusAddressType(), actualCapturedCase.getAddressType());
+    assertEquals(expectedCaseType, actualCapturedCase.getCaseType());
     assertEquals(expectedAddress.getCensusEstabType(), actualCapturedCase.getEstabType());
-    assertEquals("E", actualCapturedCase.getRegion());
+    assertEquals(expectedAddress.getCountryCode(), actualCapturedCase.getRegion());
     assertEquals(expectedAddress.getOrganisationName(), actualCapturedCase.getCeOrgName());
     assertEquals(0, actualCapturedCase.getCaseEvents().size());
-}
+  }
 
   private String createFormattedAddress(AddressIndexAddressCompositeDTO expectedAddress) {
     ArrayList<String> elements = new ArrayList<>();
@@ -464,11 +468,12 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     elements.add(expectedAddress.getAddressLine3());
     elements.add(expectedAddress.getTownName());
     elements.add(expectedAddress.getPostcode());
-    
-    return elements.stream()
+
+    return elements
+        .stream()
         .filter(e -> e != null)
         .filter(e -> !e.isEmpty())
-        .collect(Collectors.joining(", "));    
+        .collect(Collectors.joining(", "));
   }
 
   private void verifyCaseDTOContent(

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_0;
 
+import java.util.ArrayList;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.Before;
@@ -41,6 +42,7 @@ import uk.gov.ons.ctp.common.event.model.CollectionCaseCompact;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.ModifyCaseRequestDTO;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -423,6 +425,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
         .estabType(requestDTO.getEstabType().getCode())
         .region(cachedCase.getRegion())
         .ceOrgName(requestDTO.getCeOrgName())
+        .caseEvents(new ArrayList<CaseEventDTO>())
         .build();
   }
 
@@ -442,6 +445,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
         .estabType(requestDTO.getEstabType().getCode())
         .region(caseContainerDTO.getRegion())
         .ceOrgName(requestDTO.getCeOrgName())
+        .caseEvents(new ArrayList<CaseEventDTO>())
         .build();
   }
 

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.CachedCase.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.CachedCase.json
@@ -12,5 +12,6 @@
   "caseType": "HH",
   "estabType": "Household",
   "region": "E",
-  "ceOrgName": "The Cached Case Organisation"
+  "ceOrgName": "The Cached Case Organisation",
+  "caseEvents": [ ]
 }


### PR DESCRIPTION
This change basically fixes the bug exposed by:
1) Create cached case by getting a case by uprn.
2) Get case using the new case id, with 'caseEvents=true'. This would originally fail as the cached case would be created without any case events and the get code assumed that the cached case had a non null case events collection.

Cached case are now created with an empty case events collection. 
This fix has also been applied for cached cases which can be created through the new-case and modify-case endpoints.

Corresponding unit tests have been updated.
Cucumber tests also updated is it expected an empty caseEvents collection.