### PR TITLE
Cr 1070 - CC Service Must Not Allow Creation of Case where caseType CE and region N

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -636,7 +636,10 @@ public class CaseServiceImpl implements CaseService {
         .debug("Invalidate Case");
 
     CaseContainerDTO caseDetails = getCaseFromRmOrCache(caseId, false);
-    checkCaseIsNotTypeCE(caseDetails);
+    String errorMessage =
+        "All CE addresses will be validated by a Field Officer. "
+            + "It is not necessary to submit this Invalidation request.";
+    rejectIfCaseIsTypeCE(caseDetails, errorMessage);
 
     CollectionCaseCompact collectionCase = new CollectionCaseCompact(caseId);
 
@@ -1018,13 +1021,11 @@ public class CaseServiceImpl implements CaseService {
     }
   }
 
-  private void checkCaseIsNotTypeCE(CaseContainerDTO caseDetails) throws CTPException {
+  private void rejectIfCaseIsTypeCE(CaseContainerDTO caseDetails, String errorMessage)
+      throws CTPException {
     if (caseDetails.getCaseType().equals("CE")) {
-      String message =
-          "All CE addresses will be validated by a Field Officer. "
-              + "It is not necessary to submit this Invalidation request.";
-      log.with(caseDetails.getId()).warn(message);
-      throw new CTPException(Fault.BAD_REQUEST, message);
+      log.with(caseDetails.getId()).warn(errorMessage);
+      throw new CTPException(Fault.BAD_REQUEST, errorMessage);
     }
   }
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1012,7 +1012,8 @@ public class CaseServiceImpl implements CaseService {
   private void rejectIfCEInNI(
       CaseType caseType, uk.gov.ons.ctp.integration.contactcentresvc.representation.Region region)
       throws CTPException {
-    if ((caseType.name().equals("CE")) && (region.name().equals("N"))) {
+    if (caseType == CaseType.CE
+        && region == uk.gov.ons.ctp.integration.contactcentresvc.representation.Region.N) {
       String message =
           "All queries relating to Communal Establishments in Northern Ireland "
               + "should be escalated to NISRA HQ";
@@ -1023,7 +1024,7 @@ public class CaseServiceImpl implements CaseService {
 
   private void rejectIfCaseIsTypeCE(CaseContainerDTO caseDetails, String errorMessage)
       throws CTPException {
-    if (caseDetails.getCaseType().equals("CE")) {
+    if (CaseType.valueOf(caseDetails.getCaseType()) == CaseType.CE) {
       log.with(caseDetails.getId()).warn(errorMessage);
       throw new CTPException(Fault.BAD_REQUEST, errorMessage);
     }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -167,7 +167,10 @@ public class CaseServiceImpl implements CaseService {
   public CaseDTO createCaseForNewAddress(NewCaseRequestDTO caseRequestDTO) throws CTPException {
     CaseType caseType = caseRequestDTO.getCaseType();
 
-    rejectIfCEInNI(caseType, caseRequestDTO.getRegion());
+    String errorMessage =
+        "All queries relating to Communal Establishments in Northern Ireland "
+            + "should be escalated to NISRA HQ";
+    rejectIfCEInNI(caseType, caseRequestDTO.getRegion(), errorMessage);
 
     validateCompatibleEstabAndCaseType(caseType, caseRequestDTO.getEstabType());
 
@@ -639,7 +642,8 @@ public class CaseServiceImpl implements CaseService {
     String errorMessage =
         "All CE addresses will be validated by a Field Officer. "
             + "It is not necessary to submit this Invalidation request.";
-    rejectIfCaseIsTypeCE(caseDetails, errorMessage);
+    CaseType caseType = CaseType.valueOf(caseDetails.getCaseType());
+    rejectIfCaseIsTypeCE(caseType, errorMessage);
 
     CollectionCaseCompact collectionCase = new CollectionCaseCompact(caseId);
 
@@ -1010,22 +1014,18 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private void rejectIfCEInNI(
-      CaseType caseType, uk.gov.ons.ctp.integration.contactcentresvc.representation.Region region)
+      CaseType caseType,
+      uk.gov.ons.ctp.integration.contactcentresvc.representation.Region region,
+      String errorMessage)
       throws CTPException {
-    if (caseType == CaseType.CE
-        && region == uk.gov.ons.ctp.integration.contactcentresvc.representation.Region.N) {
-      String message =
-          "All queries relating to Communal Establishments in Northern Ireland "
-              + "should be escalated to NISRA HQ";
-      log.with(caseType.name()).with(region.name()).warn(message);
-      throw new CTPException(Fault.BAD_REQUEST, message);
+    if (region == uk.gov.ons.ctp.integration.contactcentresvc.representation.Region.N) {
+      rejectIfCaseIsTypeCE(caseType, errorMessage);
     }
   }
 
-  private void rejectIfCaseIsTypeCE(CaseContainerDTO caseDetails, String errorMessage)
-      throws CTPException {
-    if (CaseType.valueOf(caseDetails.getCaseType()) == CaseType.CE) {
-      log.with(caseDetails.getId()).warn(errorMessage);
+  private void rejectIfCaseIsTypeCE(CaseType caseType, String errorMessage) throws CTPException {
+    if (caseType == CaseType.CE) {
+      log.with(caseType.name()).warn(errorMessage);
       throw new CTPException(Fault.BAD_REQUEST, errorMessage);
     }
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -167,7 +167,7 @@ public class CaseServiceImpl implements CaseService {
   public CaseDTO createCaseForNewAddress(NewCaseRequestDTO caseRequestDTO) throws CTPException {
     CaseType caseType = caseRequestDTO.getCaseType();
 
-    checkCaseTypeForNewAddress(caseType, caseRequestDTO.getRegion());
+    rejectIfCEInNI(caseType, caseRequestDTO.getRegion());
 
     validateCompatibleEstabAndCaseType(caseType, caseRequestDTO.getEstabType());
 
@@ -1006,7 +1006,7 @@ public class CaseServiceImpl implements CaseService {
     return response;
   }
 
-  private void checkCaseTypeForNewAddress(
+  private void rejectIfCEInNI(
       CaseType caseType, uk.gov.ons.ctp.integration.contactcentresvc.representation.Region region)
       throws CTPException {
     if ((caseType.name().equals("CE")) && (region.name().equals("N"))) {

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -167,6 +167,8 @@ public class CaseServiceImpl implements CaseService {
   public CaseDTO createCaseForNewAddress(NewCaseRequestDTO caseRequestDTO) throws CTPException {
     CaseType caseType = caseRequestDTO.getCaseType();
 
+    checkCaseTypeForNewAddress(caseType, caseRequestDTO.getRegion());
+
     validateCompatibleEstabAndCaseType(caseType, caseRequestDTO.getEstabType());
 
     // Reject if CE with non-positive number of residents
@@ -998,6 +1000,18 @@ public class CaseServiceImpl implements CaseService {
     response.setSecureEstablishment(estabType.isSecure());
 
     return response;
+  }
+
+  private void checkCaseTypeForNewAddress(
+      CaseType caseType, uk.gov.ons.ctp.integration.contactcentresvc.representation.Region region)
+      throws CTPException {
+    if ((caseType.name().equals("CE")) && (region.name().equals("N"))) {
+      String message =
+          "All queries relating to Communal Establishments in Northern Ireland "
+              + "should be escalated to NISRA HQ";
+      log.with(caseType.name()).with(region.name()).warn(message);
+      throw new CTPException(Fault.BAD_REQUEST, message);
+    }
   }
 
   private void checkCaseIsNotTypeCE(CaseContainerDTO caseDetails) throws CTPException {

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplCreateCaseForNewAddressTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplCreateCaseForNewAddressTest.java
@@ -28,6 +28,7 @@ import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.NewCaseRequestDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 
 /**
@@ -111,6 +112,30 @@ public class CaseServiceImplCreateCaseForNewAddressTest extends CaseServiceImplT
     caseRequestDTO.setCeUsualResidents(11);
 
     doTestNewCaseForNewAddress(caseRequestDTO, "CE", true);
+  }
+
+  @Test
+  public void testNewCaseForNewAddress_ceCaseTypeNotAllowedIfRegionN() throws Exception {
+    // Test that a request for a new case where the caseType is CE and the region is N will be
+    // rejected
+    NewCaseRequestDTO caseRequestDTO =
+        FixtureHelper.loadClassFixtures(NewCaseRequestDTO[].class).get(0);
+    // Simulate condition by making the request a CE with a region of N
+    caseRequestDTO.setCaseType(CaseType.CE);
+    caseRequestDTO.setRegion(Region.N);
+
+    try {
+      doTestNewCaseForNewAddress(caseRequestDTO, "CE", true);
+      fail();
+    } catch (CTPException e) {
+      assertEquals(Fault.BAD_REQUEST, e.getFault());
+      assertTrue(
+          e.toString(),
+          e.getMessage()
+              .matches(
+                  "All queries relating to Communal Establishments "
+                      + "in Northern Ireland should be escalated to NISRA HQ"));
+    }
   }
 
   private void doTestNewCaseForNewAddress(


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The CC service must not allow creation of a case where the caseType is CE and the region is N.

Along with similar guards in other endpoints, we must not allow Serco to request creation of new case using the POST /cases endpoint if the region is 'N' and the case Type is 'CE'

If they do submit that combo we should return a 400 BAD_REQUEST with the following message :

“All queries relating to Communal Establishments in Northern Ireland should be escalated to NISRA HQ”

# What has changed
<!--- What code changes has been made -->
Changes have been made, mainly to the CaseServiceImpl, so that the newCase endpoint will:
1. Check the value of the caseType and region that are held in the NewCaseRequestDTO.
3. If the caseType is "CE" and region is "N" then throw an exception and return a BAD_REQUEST response with the error message specified above.

Relevant JUnit tests have also been amended and a new one added.

# How to test?
<!--- Describe in detail how you tested your changes. -->
Run the mock case service and the contact centre service (branch CR-1070-not-allow-ce-case-in-ni). Then make sure that the following request in Postman returns a BAD_REQUEST error with this message:
"All queries relating to Communal Establishments in Northern Ireland should be escalated to NISRA HQ"

http://localhost:8171/cases

The above POST request requires the following request body:

{
  "addressLine1": "8 Newlands Terrace",
  "addressLine2": "Flatfield",
  "addressLine3": "Brumble",
  "townName": "Exeter",
  "region": "N",
  "postcode": "EX2 5WH",
  "ceOrgName": "Claringdon House",
  "ceUsualResidents": 13,
  "dateTime": "2016-11-09T11:44:44.797",
  "caseType": "CE",
  "uprn": "3333334",
  "estabType": "ROYAL_HOUSEHOLD"
 }

and should return this:

{
    "error": {
        "code": "BAD_REQUEST",
        "timestamp": "20200713115959088",
        "message": "All queries relating to Communal Establishments in Northern Ireland should be escalated to NISRA HQ"
    }
}

whereas the same URL with a body that contains a caseType that does NOT have either a caseType of CE and/or a region of N e.g.

{
  "addressLine1": "8 Newlands Terrace",
  "addressLine2": "Flatfield",
  "addressLine3": "Brumble",
  "townName": "Exeter",
  "region": "N",
  "postcode": "EX2 5WH",
  "ceOrgName": "Claringdon House",
  "ceUsualResidents": 13,
  "dateTime": "2016-11-09T11:44:44.797",
  "caseType": "SPG",
  "uprn": "3333334",
  "estabType": "ROYAL_HOUSEHOLD"
 }

should return this:

{
    "id": "cda24938-b00e-49ae-8a49-382bef34f753",
    "caseRef": null,
    "caseType": "SPG",
    "addressType": "SPG",
    "estabType": "ROYAL_HOUSEHOLD",
    "estabDescription": "ROYAL HOUSEHOLD",
    "allowedDeliveryChannels": [
        "POST",
        "SMS"
    ],
    "createdDateTime": "2020-07-13T11:00:04.813Z",
    "lastUpdated": null,
    "addressLine1": "8 Newlands Terrace",
    "addressLine2": "Flatfield",
    "addressLine3": "Brumble",
    "townName": "Exeter",
    "region": "N",
    "postcode": "EX2 5WH",
    "ceOrgName": "Claringdon House",
    "uprn": 3333334,
    "estabUprn": null,
    "caseEvents": null,
    "secureEstablishment": true
}