### PR TITLE
Cr 1084 Refusal To Handle Region If Null

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ When running successfully version information can be obtained from the info endp
     
 * localhost:8171/info
     
-## Docker image build
+## Docker Image Build
 
 Is switched off by default for clean deploy. Switch on with;
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repository contains the Contact Centre Data service. This microservice is a
 Do the following steps to set up the code to run locally:
 * Install Java 11 locally
 * Make sure that you have a suitable settings.xml file in your local .m2 directory
-* Clone the census-contact-centre locally
+* Clone the census-contact-centre-service locally
 
 ## Running
 There are two ways of running this service:

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -896,7 +896,11 @@ public class CaseServiceImpl implements CaseService {
     address.setAddressLine3(refusalRequest.getAddressLine3());
     address.setTownName(refusalRequest.getTownName());
     address.setPostcode(refusalRequest.getPostcode());
-    address.setRegion(refusalRequest.getRegion().name());
+    uk.gov.ons.ctp.integration.contactcentresvc.representation.Region region =
+        refusalRequest.getRegion();
+    if (region != null) {
+      address.setRegion(region.name());
+    }
     address.setUprn(Long.toString(refusalRequest.getUprn().getValue()));
     refusal.setAddress(address);
 


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In the refusals endpoint, the swagger allows for flexibility over fields being present or not, because Serco may not be able to find the right case, or ion worse case scenario, we were down for a while, and they will send the refusal later.

The endpoint allows for case id of "UNKNOWN" in this case, and if they could not find the case, they may not be sure what the region is - hence the swagger allowing region to be null.

The current implementation does not meet the swagger spec re: region!
If region sent as null, we get a null pointer exception.

# What has changed
<!--- What code changes has been made -->
A small change has been made to simply check whether the region, which comes in from the RefusalRequestDTO, is null or not.

If the RefusalRequestDTO has a region that's null then the RespondentRefusalDetails will no longer attempt to have any value assigned to the region in its address details.

Therefore, instead of causing a null pointer exception, a null value of region in the request should now produce a valid response.

# How to test?
<!--- Describe in detail how you tested your changes. -->

Send a POST request to the following URL containing the following Body:

http://localhost:8171/cases/3305e937-6fb1-4ce1-9d4c-077f147789ac/refusal

{
  "caseId": "3305e937-6fb1-4ce1-9d4c-077f147789ac",
  "agentId": "123",
  "reason": "EXTRAORDINARY",
  "title": "string",
  "forename": "string",
  "surname": "string",
  "telNo": "01999999999",
  "notes": "string",
  "addressLine1": "string",
  "addressLine2": "string",
  "addressLine3": "string",
  "townName": "string",
  "region": null,
  "postcode": "EX1 2ET",
  "uprn": "100041045018",
  "dateTime": "2020-05-11T11:55:23.195+01:00",
  "callId": "string"
}

Before the changes this would have produced a null pointer exception e.g.

java.lang.NullPointerException: null
	at uk.gov.ons.ctp.integration.contactcentresvc.service.impl.CaseServiceImpl.createRespondentRefusalPayload(CaseServiceImpl.java:899)
	at uk.gov.ons.ctp.integration.contactcentresvc.service.impl.CaseServiceImpl.reportRefusal(CaseServiceImpl.java:486)
	at uk.gov.ons.ctp.integration.contactcentresvc.endpoint.CaseEndpoint.reportRefusal(CaseEndpoint.java:246)
	at jdk.internal.reflect.GeneratedMethodAccessor230.invoke(Unknown Source) etc.

However, now that the changes have been made, it should produce a valid response e.g.

{
    "id": "3305e937-6fb1-4ce1-9d4c-077f147789ac",
    "dateTime": "2020-07-15T15:45:48.830Z"
}