### PR TITLE
CR-809_Add_AD_get_UAC_endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.122</version>
+      <version>0.0.124</version>
     </dependency>
 
     <!--

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
@@ -295,6 +295,28 @@ public class CaseEndpoint implements CTPEndpoint {
     return ResponseEntity.ok(result);
   }
 
+  /**
+   * the GET end point to request a UAC from AD for a given caseid
+   *
+   * @param caseId the id of the case
+   * @param requestBodyDTO the request body
+   * @return response entity
+   * @throws CTPException something went wrong
+   */
+  @RequestMapping(value = "/{caseId}/uac", method = RequestMethod.GET)
+  @ResponseStatus(value = HttpStatus.OK)
+  public ResponseEntity<UACResponseDTO> getUACForCase(
+      @PathVariable(value = "caseId") final UUID caseId, @Valid UACRequestDTO requestParamsDTO)
+      throws CTPException {
+
+    log.with("pathParam", caseId)
+        .with("requestBody", requestParamsDTO)
+        .info("Entering GET getUACForCase");
+
+    UACResponseDTO response = caseService.getUACForCaseId(caseId, requestParamsDTO);
+    return ResponseEntity.ok(response);
+  }
+
   // ---------------------------------------------------------------
   // DUMMY ENDPOINTS FROM HERE
   // ---------------------------------------------------------------
@@ -318,31 +340,6 @@ public class CaseEndpoint implements CTPEndpoint {
     log.with("pathParam", postcode).info("Entering GET getCCSCaseByPostcode");
 
     CaseDTO response = new CaseDTO();
-    return ResponseEntity.ok(response);
-  }
-
-  /**
-   * DUMMY ENDPOINT FOR AD
-   *
-   * <p>the GET end point to request a UAC from AD for a given caseid
-   *
-   * @param caseId the id of the case
-   * @param requestBodyDTO the request body
-   * @return response entity
-   * @throws CTPException something went wrong
-   */
-  @RequestMapping(value = "/{caseId}/uac", method = RequestMethod.GET)
-  @ResponseStatus(value = HttpStatus.OK)
-  public ResponseEntity<UACResponseDTO> getUACForCase(
-      @PathVariable(value = "caseId") final UUID caseId, @Valid UACRequestDTO requestBodyDTO)
-      throws CTPException {
-
-    log.with("pathParam", caseId)
-        .with("requestBody", requestBodyDTO)
-        .info("Entering GET getUACForCase");
-
-    validateMatchingCaseId(caseId, requestBodyDTO.getCaseId());
-    UACResponseDTO response = new UACResponseDTO();
     return ResponseEntity.ok(response);
   }
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
@@ -299,7 +299,7 @@ public class CaseEndpoint implements CTPEndpoint {
    * the GET end point to request a UAC from AD for a given caseid
    *
    * @param caseId the id of the case
-   * @param requestBodyDTO the request body
+   * @param requestParamsDTO the request params
    * @return response entity
    * @throws CTPException something went wrong
    */

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/CaseService.java
@@ -15,6 +15,8 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.PostalFulfilme
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.RefusalRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.ResponseDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.SMSFulfilmentRequestDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.UACRequestDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.UACResponseDTO;
 
 /** Service responsible for dealing with Cases */
 public interface CaseService {
@@ -44,6 +46,8 @@ public interface CaseService {
 
   String getLaunchURLForCaseId(final UUID caseId, LaunchRequestDTO requestParamsDTO)
       throws CTPException;
+
+  UACResponseDTO getUACForCaseId(UUID caseId, UACRequestDTO requestParamsDTO) throws CTPException;
 
   ResponseDTO invalidateCase(InvalidateCaseRequestDTO invalidateCaseRequestDTO) throws CTPException;
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -552,14 +552,11 @@ public class CaseServiceImpl implements CaseService {
     SingleUseQuestionnaireIdDTO newQuestionnaireIdDto =
         getNewQidForCase(caseDetails, requestParamsDTO.getIndividual());
 
-    UACResponseDTO response =
-        UACResponseDTO.builder()
-            .id(newQuestionnaireIdDto.getQuestionnaireId())
-            .uac(newQuestionnaireIdDto.getUac())
-            .dateTime(DateTimeUtil.nowUTC())
-            .build();
-
-    return response;
+    return UACResponseDTO.builder()
+        .id(newQuestionnaireIdDto.getQuestionnaireId())
+        .uac(newQuestionnaireIdDto.getUac())
+        .dateTime(DateTimeUtil.nowUTC())
+        .build();
   }
 
   /**

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/CaseServiceFixture.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/CaseServiceFixture.java
@@ -20,12 +20,14 @@ public final class CaseServiceFixture {
   public static final String AN_ADDRESS_LINE_1 = "1 High Street";
   public static final String AN_ADDRESS_LINE_2 = "Delph";
   public static final String AN_ADDRESS_LINE_3 = "Oldham";
-  public static final String A_TOWN_NAME = "Manchester";
-  public static final String A_POSTCODE = "OL3 5DJ";
   public static final Region A_REGION = Region.E;
   public static final String A_RESPONSE_DATE_TIME = "2019-03-28T11:56:40.705Z";
   public static final Date A_REQUEST_DATE_TIME = new Date();
   public static final String AN_AGENT_ID = "123";
   public static final String A_QUESTIONNAIRE_ID = "566786126";
   public static final String A_UAC = "dummy-uac-value";
+  public static final String NI_LAUNCH_ERR_MSG =
+      "All Northern Ireland calls from CE Managers are to be escalated to the NI management team.";
+  public static final String UNIT_LAUNCH_ERR_MSG =
+      "A CE Manager form can only be launched against an establishment address not a UNIT.";
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/CaseServiceFixture.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/CaseServiceFixture.java
@@ -27,4 +27,5 @@ public final class CaseServiceFixture {
   public static final Date A_REQUEST_DATE_TIME = new Date();
   public static final String AN_AGENT_ID = "123";
   public static final String A_QUESTIONNAIRE_ID = "566786126";
+  public static final String A_UAC = "dummy-uac-value";
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
@@ -103,11 +103,7 @@ public abstract class EndpointSecurityTest {
     UUID caseId = UUID.randomUUID();
     ResponseEntity<String> response =
         restTemplate.getForEntity(
-            base.toString()
-                + "/cases/"
-                + caseId
-                + "/uac?adLocation=12345&individual=false&caseId="
-                + caseId,
+            base.toString() + "/cases/" + caseId + "/uac?adLocationId=12345&individual=false",
             String.class);
     assertEquals(expectedStatus, response.getStatusCode());
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetUACTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetUACTest.java
@@ -9,6 +9,8 @@ import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.AN_
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_QUESTIONNAIRE_ID;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_REGION;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_UAC;
+import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.NI_LAUNCH_ERR_MSG;
+import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UNIT_LAUNCH_ERR_MSG;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_0;
 
 import java.util.Optional;
@@ -23,7 +25,6 @@ import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.domain.FormType;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
-import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.SingleUseQuestionnaireIdDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.UACRequestDTO;
@@ -65,7 +66,7 @@ public class CaseServiceImplGetUACTest extends CaseServiceImplTestBase {
   }
 
   @Test
-  public void testGetUACHICase() throws Exception {
+  public void testGetUACHICase() {
     try {
       doGetUACTest("HI", false);
       fail();
@@ -102,34 +103,32 @@ public class CaseServiceImplGetUACTest extends CaseServiceImplTestBase {
 
   @Test
   public void shouldRejectCeManagerFormFromUnitRegionE() {
-    CaseContainerDTO dto = mockGetCaseById("CE", "U", "E");
-    assertThatCeManagerFormFromUnitRegionIsRejected(dto);
+    mockGetCaseById("CE", "U", "E");
+    assertThatInvalidLaunchComboIsRejected(UNIT_LAUNCH_ERR_MSG);
   }
 
   @Test
   public void shouldRejectCeManagerFormFromUnitRegionW() {
-    CaseContainerDTO dto = mockGetCaseById("CE", "U", "W");
-    assertThatCeManagerFormFromUnitRegionIsRejected(dto);
+    mockGetCaseById("CE", "U", "W");
+    assertThatInvalidLaunchComboIsRejected(UNIT_LAUNCH_ERR_MSG);
   }
 
   @Test
   public void shouldRejectCeManagerFormFromUnitRegionN() {
-    CaseContainerDTO dto = mockGetCaseById("CE", "U", "N");
-    assertThatCeManagerFormFromUnitRegionIsRejected(dto);
+    mockGetCaseById("CE", "U", "N");
+    assertThatInvalidLaunchComboIsRejected(UNIT_LAUNCH_ERR_MSG);
   }
 
   @Test
   public void shouldRejectCeManagerFormFromEstabRegionN() {
-    CaseContainerDTO dto = mockGetCaseById("CE", "E", "N");
-    assertThatInvalidLaunchComboIsRejected(
-        dto,
-        "All Northern Ireland calls from CE Managers are to be escalated to the NI management team.");
+    mockGetCaseById("CE", "E", "N");
+    assertThatInvalidLaunchComboIsRejected(NI_LAUNCH_ERR_MSG);
   }
 
   @SneakyThrows
-  private void assertThatInvalidLaunchComboIsRejected(CaseContainerDTO dto, String expectedMsg) {
+  private void assertThatInvalidLaunchComboIsRejected(String expectedMsg) {
     try {
-      doGetUACTest(false, dto, FormType.C);
+      doGetUACTest(false, FormType.C);
       fail();
     } catch (CTPException e) {
       assertEquals(Fault.BAD_REQUEST, e.getFault());
@@ -137,20 +136,12 @@ public class CaseServiceImplGetUACTest extends CaseServiceImplTestBase {
     }
   }
 
-  @SneakyThrows
-  private void assertThatCeManagerFormFromUnitRegionIsRejected(CaseContainerDTO dto) {
-    assertThatInvalidLaunchComboIsRejected(
-        dto, "A CE Manager form can only be launched against an establishment address not a UNIT.");
-  }
-
   private void doGetUACTest(String caseType, boolean individual) throws Exception {
-    CaseContainerDTO caseFromCaseService = mockGetCaseById(caseType, "U", A_REGION.name());
-    doGetUACTest(individual, caseFromCaseService, FormType.H);
+    mockGetCaseById(caseType, "U", A_REGION.name());
+    doGetUACTest(individual, FormType.H);
   }
 
-  private void doGetUACTest(
-      boolean individual, CaseContainerDTO caseFromCaseService, FormType formType)
-      throws Exception {
+  private void doGetUACTest(boolean individual, FormType formType) throws Exception {
 
     // Fake RM response for creating questionnaire ID
     SingleUseQuestionnaireIdDTO newQuestionnaireIdDto = new SingleUseQuestionnaireIdDTO();

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetUACTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetUACTest.java
@@ -1,0 +1,174 @@
+package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.AN_AGENT_ID;
+import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_QUESTIONNAIRE_ID;
+import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_REGION;
+import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_UAC;
+import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_0;
+
+import java.util.Optional;
+import java.util.UUID;
+import lombok.SneakyThrows;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ctp.common.domain.FormType;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
+import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.SingleUseQuestionnaireIdDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.UACRequestDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.UACResponseDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
+
+/** Unit Test {@link CaseService#getUACForCaseId(UUID, UACRequestDTO) getUACForCaseId}. */
+@RunWith(MockitoJUnitRunner.class)
+public class CaseServiceImplGetUACTest extends CaseServiceImplTestBase {
+
+  @Test
+  public void testGetUACCECase() throws Exception {
+    doGetUACTest("CE", false);
+  }
+
+  @Test
+  public void testGetUACCECaseForIndividual() throws Exception {
+    doGetUACTest("CE", true);
+  }
+
+  @Test
+  public void testGetUACHHCase() throws Exception {
+    doGetUACTest("HH", false);
+  }
+
+  @Test
+  public void testGetUACHHCaseForIndividual() throws Exception {
+    doGetUACTest("HH", true);
+  }
+
+  @Test
+  public void testGetUACSPGCase() throws Exception {
+    doGetUACTest("SPG", false);
+  }
+
+  @Test
+  public void testGetUACSPGCaseForIndividual() throws Exception {
+    doGetUACTest("SPG", true);
+  }
+
+  @Test
+  public void testGetUACHICase() throws Exception {
+    try {
+      doGetUACTest("HI", false);
+      fail();
+    } catch (Exception e) {
+      assertTrue(e.getMessage(), e.getMessage().contains("must be SPG, CE or HH"));
+    }
+  }
+
+  @Test(expected = CTPException.class)
+  public void testGetUAC_caseServiceNotFoundException_cachedCase() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
+        .when(caseServiceClient)
+        .getCaseById(UUID_0, false);
+    Mockito.when(dataRepo.readCachedCaseById(UUID_0)).thenReturn(Optional.of(new CachedCase()));
+    target.getUACForCaseId(UUID_0, new UACRequestDTO());
+  }
+
+  @Test(expected = ResponseStatusException.class)
+  public void testGetUAC_caseServiceNotFoundException_noCachedCase() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
+        .when(caseServiceClient)
+        .getCaseById(UUID_0, false);
+    Mockito.when(dataRepo.readCachedCaseById(UUID_0)).thenReturn(Optional.empty());
+    target.getUACForCaseId(UUID_0, new UACRequestDTO());
+  }
+
+  @Test(expected = ResponseStatusException.class)
+  public void testGetUAC_caseServiceResponseStatusException() throws Exception {
+    Mockito.doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT))
+        .when(caseServiceClient)
+        .getCaseById(UUID_0, false);
+    target.getUACForCaseId(UUID_0, new UACRequestDTO());
+  }
+
+  @Test
+  public void shouldRejectCeManagerFormFromUnitRegionE() {
+    CaseContainerDTO dto = mockGetCaseById("CE", "U", "E");
+    assertThatCeManagerFormFromUnitRegionIsRejected(dto);
+  }
+
+  @Test
+  public void shouldRejectCeManagerFormFromUnitRegionW() {
+    CaseContainerDTO dto = mockGetCaseById("CE", "U", "W");
+    assertThatCeManagerFormFromUnitRegionIsRejected(dto);
+  }
+
+  @Test
+  public void shouldRejectCeManagerFormFromUnitRegionN() {
+    CaseContainerDTO dto = mockGetCaseById("CE", "U", "N");
+    assertThatCeManagerFormFromUnitRegionIsRejected(dto);
+  }
+
+  @Test
+  public void shouldRejectCeManagerFormFromEstabRegionN() {
+    CaseContainerDTO dto = mockGetCaseById("CE", "E", "N");
+    assertThatInvalidLaunchComboIsRejected(
+        dto,
+        "All Northern Ireland calls from CE Managers are to be escalated to the NI management team.");
+  }
+
+  @SneakyThrows
+  private void assertThatInvalidLaunchComboIsRejected(CaseContainerDTO dto, String expectedMsg) {
+    try {
+      doGetUACTest(false, dto, FormType.C);
+      fail();
+    } catch (CTPException e) {
+      assertEquals(Fault.BAD_REQUEST, e.getFault());
+      assertTrue(e.getMessage(), e.getMessage().contains(expectedMsg));
+    }
+  }
+
+  @SneakyThrows
+  private void assertThatCeManagerFormFromUnitRegionIsRejected(CaseContainerDTO dto) {
+    assertThatInvalidLaunchComboIsRejected(
+        dto, "A CE Manager form can only be launched against an establishment address not a UNIT.");
+  }
+
+  private void doGetUACTest(String caseType, boolean individual) throws Exception {
+    CaseContainerDTO caseFromCaseService = mockGetCaseById(caseType, "U", A_REGION.name());
+    doGetUACTest(individual, caseFromCaseService, FormType.H);
+  }
+
+  private void doGetUACTest(
+      boolean individual, CaseContainerDTO caseFromCaseService, FormType formType)
+      throws Exception {
+
+    // Fake RM response for creating questionnaire ID
+    SingleUseQuestionnaireIdDTO newQuestionnaireIdDto = new SingleUseQuestionnaireIdDTO();
+    newQuestionnaireIdDto.setQuestionnaireId(A_QUESTIONNAIRE_ID);
+    newQuestionnaireIdDto.setUac(A_UAC);
+    newQuestionnaireIdDto.setFormType(formType.name());
+    Mockito.when(caseServiceClient.getSingleUseQuestionnaireId(eq(UUID_0), eq(individual), any()))
+        .thenReturn(newQuestionnaireIdDto);
+
+    UACRequestDTO requestsFromCCSvc =
+        UACRequestDTO.builder().adLocationId(AN_AGENT_ID).individual(individual).build();
+
+    long timeBeforeInvocation = System.currentTimeMillis();
+    UACResponseDTO uac = target.getUACForCaseId(UUID_0, requestsFromCCSvc);
+    long timeAfterInvocation = System.currentTimeMillis();
+
+    assertEquals(A_UAC, uac.getUac());
+    assertEquals(A_QUESTIONNAIRE_ID, uac.getId());
+    verifyTimeInExpectedRange(timeBeforeInvocation, timeAfterInvocation, uac.getDateTime());
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
@@ -8,7 +8,6 @@ import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.Mockito.when;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.AN_AGENT_ID;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_QUESTIONNAIRE_ID;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_REGION;
@@ -109,11 +108,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
         .when(caseServiceClient)
         .getCaseById(UUID_0, false);
     Mockito.when(dataRepo.readCachedCaseById(UUID_0)).thenReturn(Optional.of(new CachedCase()));
-    List<LaunchRequestDTO> requestsFromCCSvc =
-        FixtureHelper.loadClassFixtures(LaunchRequestDTO[].class);
-    LaunchRequestDTO launchRequestDTO = requestsFromCCSvc.get(0);
-    launchRequestDTO.setIndividual(false);
-    target.getLaunchURLForCaseId(UUID_0, launchRequestDTO);
+    target.getLaunchURLForCaseId(UUID_0, new LaunchRequestDTO());
   }
 
   @Test(expected = ResponseStatusException.class)
@@ -122,11 +117,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
         .when(caseServiceClient)
         .getCaseById(UUID_0, false);
     Mockito.when(dataRepo.readCachedCaseById(UUID_0)).thenReturn(Optional.empty());
-    List<LaunchRequestDTO> requestsFromCCSvc =
-        FixtureHelper.loadClassFixtures(LaunchRequestDTO[].class);
-    LaunchRequestDTO launchRequestDTO = requestsFromCCSvc.get(0);
-    launchRequestDTO.setIndividual(true);
-    target.getLaunchURLForCaseId(UUID_0, launchRequestDTO);
+    target.getLaunchURLForCaseId(UUID_0, new LaunchRequestDTO());
   }
 
   @Test(expected = ResponseStatusException.class)
@@ -134,11 +125,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
     Mockito.doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT))
         .when(caseServiceClient)
         .getCaseById(UUID_0, false);
-    List<LaunchRequestDTO> requestsFromCCSvc =
-        FixtureHelper.loadClassFixtures(LaunchRequestDTO[].class);
-    LaunchRequestDTO launchRequestDTO = requestsFromCCSvc.get(0);
-    launchRequestDTO.setIndividual(true);
-    target.getLaunchURLForCaseId(UUID_0, launchRequestDTO);
+    target.getLaunchURLForCaseId(UUID_0, new LaunchRequestDTO());
   }
 
   @SneakyThrows
@@ -159,25 +146,25 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
   }
 
   @Test
-  public void shouldRejectCeManagerFormFromUnitRegionEast() {
+  public void shouldRejectCeManagerFormFromUnitRegionE() {
     CaseContainerDTO dto = mockGetCaseById("CE", "U", "E");
     assertThatCeManagerFormFromUnitRegionIsRejected(dto);
   }
 
   @Test
-  public void shouldRejectCeManagerFormFromUnitRegionWest() {
+  public void shouldRejectCeManagerFormFromUnitRegionW() {
     CaseContainerDTO dto = mockGetCaseById("CE", "U", "W");
     assertThatCeManagerFormFromUnitRegionIsRejected(dto);
   }
 
   @Test
-  public void shouldRejectCeManagerFormFromUnitRegionNorth() {
+  public void shouldRejectCeManagerFormFromUnitRegionN() {
     CaseContainerDTO dto = mockGetCaseById("CE", "U", "N");
     assertThatCeManagerFormFromUnitRegionIsRejected(dto);
   }
 
   @Test
-  public void shouldRejectNorthernIslandCallsFromCeManagers() {
+  public void shouldRejectCeManagerFormFromEstabRegionN() {
     CaseContainerDTO dto = mockGetCaseById("CE", "E", "N");
     assertThatInvalidLaunchComboIsRejected(
         dto,
@@ -249,16 +236,6 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
     } else {
       assertNull(individualCaseIdCaptor.getValue());
     }
-  }
-
-  private CaseContainerDTO mockGetCaseById(String caseType, String addressLevel, String region) {
-    CaseContainerDTO caseFromCaseService =
-        FixtureHelper.loadPackageFixtures(CaseContainerDTO[].class).get(0);
-    caseFromCaseService.setCaseType(caseType);
-    caseFromCaseService.setAddressLevel(addressLevel);
-    caseFromCaseService.setRegion(region);
-    when(caseServiceClient.getCaseById(eq(UUID_0), any())).thenReturn(caseFromCaseService);
-    return caseFromCaseService;
   }
 
   private void doLaunchTest(String caseType, boolean individual) throws Exception {

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -5,6 +5,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_0;
 
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -15,6 +17,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
+import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.event.EventPublisher;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
 import uk.gov.ons.ctp.common.event.EventPublisher.EventType;
@@ -22,6 +25,7 @@ import uk.gov.ons.ctp.common.event.EventPublisher.Source;
 import uk.gov.ons.ctp.common.event.model.EventPayload;
 import uk.gov.ons.ctp.common.time.DateTimeUtil;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.CaseServiceClientServiceImpl;
+import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.common.product.ProductReference;
 import uk.gov.ons.ctp.integration.contactcentresvc.CCSvcBeanMapper;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.AppConfig;
@@ -83,5 +87,15 @@ public abstract class CaseServiceImplTestBase {
 
   void verifyEventNotSent(EventType type) {
     verify(eventPublisher, never()).sendEvent(eq(type), any(), any(), any());
+  }
+
+  CaseContainerDTO mockGetCaseById(String caseType, String addressLevel, String region) {
+    CaseContainerDTO caseFromCaseService =
+        FixtureHelper.loadPackageFixtures(CaseContainerDTO[].class).get(0);
+    caseFromCaseService.setCaseType(caseType);
+    caseFromCaseService.setAddressLevel(addressLevel);
+    caseFromCaseService.setRegion(region);
+    when(caseServiceClient.getCaseById(eq(UUID_0), any())).thenReturn(caseFromCaseService);
+    return caseFromCaseService;
   }
 }


### PR DESCRIPTION
# Motivation and Context
Add endpoint for assisted digital operative to obtain a UAC for a case. 

# What has changed
New endpoint added for url path /cases/{caseId}/uac with query parameters String adLocationId and Boolean individual. Business logic in service layer identical to the endpoint to obtain a launch URL with JWT session parameter.  

# How to test?
Unit tests added to cover new functionality. Endpoint can be hit on running application with Postman or Curl. Deployed to Dev and run against present cucumber tests.

# Links
Kanban board task: https://collaborate2.ons.gov.uk/jira/browse/CR-809
census-contact-centre-service-api dependency: https://github.com/ONSdigital/census-contact-centre-service-api/pull/58
