### PR TITLE
Cr 1111 put endpoint should cache events

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapper.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapper.java
@@ -81,7 +81,12 @@ public class CCSvcBeanMapper extends ConfigurableMapper {
         .byDefault()
         .register();
 
-    factory.classMap(CachedCase.class, CaseContainerDTO.class).byDefault().register();
+    factory
+        .classMap(CachedCase.class, CaseContainerDTO.class)
+        .field("ceOrgName", "organisationName")
+        .byDefault()
+        .register();
+
     factory.classMap(CaseContainerDTO.class, Address.class).byDefault().register();
     factory.classMap(CaseContainerDTO.class, AddressCompact.class).byDefault().register();
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/cloud/CachedCase.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/cloud/CachedCase.java
@@ -1,7 +1,9 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.cloud;
 
+import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import javax.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -43,5 +45,5 @@ public class CachedCase {
 
   private String ceOrgName;
 
-  private List<CaseEventDTO> caseEvents;
+  @Builder.Default @NotNull private List<CaseEventDTO> caseEvents = new ArrayList<>();
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -495,6 +495,7 @@ public class CaseServiceImpl implements CaseService {
     UUID caseId = originalCaseId;
 
     CaseContainerDTO caseDetails = getCaseFromRmOrCache(originalCaseId, true);
+    caseDetails.setCreatedDateTime(DateTimeUtil.nowUTC());
     CaseType requestedCaseType = modifyRequestDTO.getCaseType();
     CaseType existingCaseType = CaseType.valueOf(caseDetails.getCaseType());
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -323,8 +323,7 @@ public class CaseServiceImpl implements CaseService {
       UniquePropertyReferenceNumber uprn, CaseQueryRequestDTO requestParamsDTO)
       throws CTPException {
     log.with("uprn", uprn).debug("Fetching latest case details by UPRN");
-    boolean addCaseEvents = requestParamsDTO.getCaseEvents();
-    Optional<CaseDTO> latest = getLatestCaseByUprn(uprn, addCaseEvents);
+    Optional<CaseDTO> latest = getLatestCaseByUprn(uprn, requestParamsDTO.getCaseEvents());
 
     CaseDTO response;
     if (latest.isPresent()) {
@@ -955,8 +954,7 @@ public class CaseServiceImpl implements CaseService {
 
   private List<CaseContainerDTO> getCasesFromRm(long uprn, boolean getCaseEvents) {
     var caseList = caseServiceClient.getCaseByUprn(uprn, getCaseEvents);
-    caseList.stream().map(c -> filterCaseEvents(c, getCaseEvents)).collect(toList());
-    return caseList;
+    return caseList.stream().map(c -> filterCaseEvents(c, getCaseEvents)).collect(toList());
   }
 
   /**

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -389,7 +389,6 @@ public class CaseServiceImpl implements CaseService {
     cachedCase.setAddressLine2(modifyRequestDTO.getAddressLine2());
     cachedCase.setAddressLine3(modifyRequestDTO.getAddressLine3());
     cachedCase.setCeOrgName(modifyRequestDTO.getCeOrgName());
-    cachedCase.setCaseEvents(new ArrayList<CaseEventDTO>());
     dataRepo.writeCachedCase(cachedCase);
   }
 
@@ -456,6 +455,7 @@ public class CaseServiceImpl implements CaseService {
     response.setAddressLine3(modifyRequestDTO.getAddressLine3());
     response.setCeOrgName(modifyRequestDTO.getCeOrgName());
     response.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
+    response.setCaseEvents(Collections.emptyList());
   }
 
   @Override

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -465,7 +465,7 @@ public class CaseServiceImpl implements CaseService {
     UUID originalCaseId = modifyRequestDTO.getCaseId();
     UUID caseId = originalCaseId;
 
-    CaseContainerDTO caseDetails = getCaseFromRmOrCache(originalCaseId, false);
+    CaseContainerDTO caseDetails = getCaseFromRmOrCache(originalCaseId, true);
     rejectHouseholdIndividual(caseDetails);
     CaseType requestedCaseType = modifyRequestDTO.getCaseType();
     CaseType existingCaseType = CaseType.valueOf(caseDetails.getCaseType());

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapperTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSvcBeanMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.ons.ctp.integration.contactcentresvc;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
+import java.util.List;
 import ma.glasnost.orika.MapperFacade;
 import org.junit.Test;
 import uk.gov.ons.ctp.common.FixtureHelper;
@@ -19,6 +20,16 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
 public class CCSvcBeanMapperTest {
 
   private MapperFacade mapperFacade = new CCSvcBeanMapper();
+
+  private void verifyMapping(List<EventDTO> sourceList, List<CaseEventDTO> destinationList) {
+    for (int i = 0; i < sourceList.size(); i++) {
+      EventDTO sourceEvent = sourceList.get(i);
+      CaseEventDTO destinationEvent = destinationList.get(i);
+      assertEquals(sourceEvent.getDescription(), destinationEvent.getDescription());
+      assertEquals(sourceEvent.getEventType(), destinationEvent.getCategory());
+      assertEquals(sourceEvent.getCreatedDateTime(), destinationEvent.getCreatedDateTime());
+    }
+  }
 
   @Test
   public void shouldMapCaseContainerDTO_CaseDTO() {
@@ -40,13 +51,30 @@ public class CCSvcBeanMapperTest {
     assertEquals(source.getEstabUprn(), String.valueOf(destination.getEstabUprn().getValue()));
     assertEquals(source.getCreatedDateTime(), destination.getCreatedDateTime());
     assertEquals(source.getLastUpdated(), destination.getLastUpdated());
-    for (int i = 0; i < source.getCaseEvents().size(); i++) {
-      EventDTO sourceEvent = source.getCaseEvents().get(i);
-      CaseEventDTO destinationEvent = destination.getCaseEvents().get(i);
-      assertEquals(sourceEvent.getDescription(), destinationEvent.getDescription());
-      assertEquals(sourceEvent.getEventType(), destinationEvent.getCategory());
-      assertEquals(sourceEvent.getCreatedDateTime(), destinationEvent.getCreatedDateTime());
-    }
+
+    verifyMapping(source.getCaseEvents(), destination.getCaseEvents());
+  }
+
+  @Test
+  public void shouldMapCaseContainerDtoToCachedCase() {
+    CaseContainerDTO source = FixtureHelper.loadClassFixtures(CaseContainerDTO[].class).get(0);
+    CachedCase destination = mapperFacade.map(source, CachedCase.class);
+
+    assertEquals(source.getId().toString(), destination.getId());
+    assertEquals(source.getUprn(), destination.getUprn());
+    assertEquals(source.getCreatedDateTime(), destination.getCreatedDateTime());
+    assertEquals(source.getAddressLine1(), destination.getAddressLine1());
+    assertEquals(source.getAddressLine2(), destination.getAddressLine2());
+    assertEquals(source.getAddressLine3(), destination.getAddressLine3());
+    assertEquals(source.getTownName(), destination.getTownName());
+    assertEquals(source.getPostcode(), destination.getPostcode());
+    assertEquals(source.getAddressType(), destination.getAddressType());
+    assertEquals(source.getCaseType(), destination.getCaseType().name());
+    assertEquals(source.getEstabType(), destination.getEstabType());
+    assertEquals(source.getRegion(), destination.getRegion());
+    assertEquals(source.getOrganisationName(), destination.getCeOrgName());
+
+    verifyMapping(source.getCaseEvents(), destination.getCaseEvents());
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplCreateCaseForNewAddressTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplCreateCaseForNewAddressTest.java
@@ -5,7 +5,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.times;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Optional;
 import org.junit.Before;
@@ -27,7 +26,6 @@ import uk.gov.ons.ctp.common.event.model.CollectionCaseNewAddress;
 import uk.gov.ons.ctp.common.event.model.NewAddress;
 import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.NewCaseRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.Region;
@@ -160,7 +158,6 @@ public class CaseServiceImplCreateCaseForNewAddressTest extends CaseServiceImplT
     String caseTypeName = caseRequestDTO.getCaseType().name();
     expectedCase.setAddressType(expectedAddressType);
     expectedCase.setEstabType(caseRequestDTO.getEstabType().getCode());
-    expectedCase.setCaseEvents(new ArrayList<CaseEventDTO>());
     assertEquals(expectedCase, storedCase);
 
     // Verify the NewAddressEvent

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByCaseRefTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByCaseRefTest.java
@@ -1,18 +1,14 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -22,13 +18,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.CaseType;
-import uk.gov.ons.ctp.common.domain.EstabType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.CaseServiceSettings;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseQueryRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 
@@ -148,84 +142,6 @@ public class CaseServiceImplGetCaseByCaseRefTest extends CaseServiceImplTestBase
     CaseDTO results = target.getCaseByCaseReference(VALID_CASE_REF, requestParams);
     CaseDTO expectedCaseResult = createExpectedCaseDTO(caseFromCaseService, caseEvents);
     verifyCase(results, expectedCaseResult, caseEvents);
-  }
-
-  private UniquePropertyReferenceNumber createUprn(String uprn) {
-    return uprn == null ? null : new UniquePropertyReferenceNumber(uprn);
-  }
-
-  private CaseDTO createExpectedCaseDTO(CaseContainerDTO caseFromCaseService, boolean caseEvents) {
-
-    CaseDTO expectedCaseResult =
-        CaseDTO.builder()
-            .id(caseFromCaseService.getId())
-            .caseRef(caseFromCaseService.getCaseRef())
-            .caseType(caseFromCaseService.getCaseType())
-            .estabType(EstabType.forCode(caseFromCaseService.getEstabType()))
-            .estabDescription(caseFromCaseService.getEstabType())
-            .allowedDeliveryChannels(ALL_DELIVERY_CHANNELS)
-            .createdDateTime(caseFromCaseService.getCreatedDateTime())
-            .lastUpdated(caseFromCaseService.getLastUpdated())
-            .addressLine1(caseFromCaseService.getAddressLine1())
-            .addressLine2(caseFromCaseService.getAddressLine2())
-            .addressLine3(caseFromCaseService.getAddressLine3())
-            .addressType(caseFromCaseService.getAddressType())
-            .townName(caseFromCaseService.getTownName())
-            .region(caseFromCaseService.getRegion().substring(0, 1))
-            .postcode(caseFromCaseService.getPostcode())
-            .ceOrgName(caseFromCaseService.getOrganisationName())
-            .uprn(createUprn(caseFromCaseService.getUprn()))
-            .estabUprn(createUprn(caseFromCaseService.getEstabUprn()))
-            .secureEstablishment(caseFromCaseService.isSecureEstablishment())
-            .build();
-    if (caseEvents) {
-      List<CaseEventDTO> expectedCaseEvents =
-          caseFromCaseService
-              .getCaseEvents()
-              .stream()
-              .filter(e -> !e.getDescription().contains("Should be filtered out"))
-              .map(
-                  e ->
-                      CaseEventDTO.builder()
-                          .description(e.getDescription())
-                          .category(e.getEventType())
-                          .createdDateTime(e.getCreatedDateTime())
-                          .build())
-              .collect(Collectors.toList());
-      expectedCaseResult.setCaseEvents(expectedCaseEvents);
-    }
-    return expectedCaseResult;
-  }
-
-  private void verifyCase(CaseDTO results, CaseDTO expectedCaseResult, boolean caseEventsExpected)
-      throws Exception {
-    assertEquals(expectedCaseResult.getId(), results.getId());
-    assertEquals(expectedCaseResult.getCaseRef(), results.getCaseRef());
-    assertEquals(expectedCaseResult.getCaseType(), results.getCaseType());
-    assertEquals(expectedCaseResult.getCeOrgName(), results.getCeOrgName());
-    assertEquals(
-        expectedCaseResult.getAllowedDeliveryChannels(), results.getAllowedDeliveryChannels());
-
-    if (caseEventsExpected) {
-      // Note that the test data contains 3 events, but the 'X11' event is filtered out as it is not
-      // on the whitelist
-      assertEquals(2, results.getCaseEvents().size());
-      CaseEventDTO event = results.getCaseEvents().get(0);
-      assertEquals("Initial creation of case", event.getDescription());
-      assertEquals("CASE_CREATED", event.getCategory());
-      assertEquals(asMillis("2019-05-14T16:11:41.343+01:00"), event.getCreatedDateTime().getTime());
-      event = results.getCaseEvents().get(1);
-      assertEquals("Create Household Visit", event.getDescription());
-      assertEquals("CASE_UPDATED", event.getCategory());
-      assertEquals(asMillis("2019-05-16T12:12:12.343Z"), event.getCreatedDateTime().getTime());
-    } else {
-      assertNull(results.getCaseEvents());
-    }
-
-    assertEquals(expectedCaseResult, results);
-    Mockito.verify(dataRepo, never()).writeCachedCase(any());
-    Mockito.verify(addressSvc, never()).uprnQuery(anyLong());
-    verifyEventNotSent();
   }
 
   private List<CaseContainerDTO> casesFromCaseService() {

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByCaseRefTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByCaseRefTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.util.List;
-import java.util.Set;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -21,7 +20,6 @@ import uk.gov.ons.ctp.common.domain.CaseType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.config.CaseServiceSettings;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseQueryRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
@@ -41,11 +39,7 @@ public class CaseServiceImplGetCaseByCaseRefTest extends CaseServiceImplTestBase
 
   @Before
   public void setup() {
-    // For case retrieval, mock out a whitelist of allowable case events
-    CaseServiceSettings caseServiceSettings = new CaseServiceSettings();
-    Set<String> whitelistedSet = Set.of("CASE_CREATED", "CASE_UPDATED");
-    caseServiceSettings.setWhitelistedEventCategories(whitelistedSet);
-    Mockito.when(appConfig.getCaseServiceSettings()).thenReturn(caseServiceSettings);
+    mockCaseEventWhiteList();
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import lombok.SneakyThrows;
 import org.junit.Before;
@@ -32,7 +31,6 @@ import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
-import uk.gov.ons.ctp.integration.contactcentresvc.config.CaseServiceSettings;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseQueryRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
@@ -53,11 +51,7 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
 
   @Before
   public void setup() {
-    // For case retrieval, mock out a whitelist of allowable case events
-    CaseServiceSettings caseServiceSettings = new CaseServiceSettings();
-    Set<String> whitelistedSet = Set.of("CASE_CREATED", "CASE_UPDATED");
-    caseServiceSettings.setWhitelistedEventCategories(whitelistedSet);
-    Mockito.when(appConfig.getCaseServiceSettings()).thenReturn(caseServiceSettings);
+    mockCaseEventWhiteList();
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
@@ -1,13 +1,10 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_0;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_1;
 
@@ -15,7 +12,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
 import lombok.SneakyThrows;
 import org.junit.Before;
 import org.junit.Test;
@@ -26,14 +22,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.CaseType;
-import uk.gov.ons.ctp.common.domain.EstabType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.CaseServiceSettings;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
-import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseQueryRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 
@@ -149,90 +143,8 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
     CaseQueryRequestDTO requestParams = new CaseQueryRequestDTO(caseEvents);
     CaseDTO results = target.getCaseById(UUID_0, requestParams);
 
-    verifyCase(results, expectedCaseResult, caseEvents, cached);
+    verifyCase(results, expectedCaseResult, caseEvents);
     assertEquals(asMillis("2019-05-14T16:11:41.343+01:00"), results.getCreatedDateTime().getTime());
-  }
-
-  private UniquePropertyReferenceNumber createUprn(String uprn) {
-    return uprn == null ? null : new UniquePropertyReferenceNumber(uprn);
-  }
-
-  private CaseDTO createExpectedCaseDTO(CaseContainerDTO caseFromCaseService, boolean caseEvents) {
-
-    CaseDTO expectedCaseResult =
-        CaseDTO.builder()
-            .id(caseFromCaseService.getId())
-            .caseRef(caseFromCaseService.getCaseRef())
-            .caseType(caseFromCaseService.getCaseType())
-            .estabType(EstabType.forCode(caseFromCaseService.getEstabType()))
-            .estabDescription(caseFromCaseService.getEstabType())
-            .allowedDeliveryChannels(ALL_DELIVERY_CHANNELS)
-            .createdDateTime(caseFromCaseService.getCreatedDateTime())
-            .lastUpdated(caseFromCaseService.getLastUpdated())
-            .addressLine1(caseFromCaseService.getAddressLine1())
-            .addressLine2(caseFromCaseService.getAddressLine2())
-            .addressLine3(caseFromCaseService.getAddressLine3())
-            .addressType(caseFromCaseService.getAddressType())
-            .townName(caseFromCaseService.getTownName())
-            .region(caseFromCaseService.getRegion().substring(0, 1))
-            .postcode(caseFromCaseService.getPostcode())
-            .ceOrgName(caseFromCaseService.getOrganisationName())
-            .uprn(createUprn(caseFromCaseService.getUprn()))
-            .estabUprn(createUprn(caseFromCaseService.getEstabUprn()))
-            .secureEstablishment(caseFromCaseService.isSecureEstablishment())
-            .build();
-    if (caseEvents) {
-      List<CaseEventDTO> expectedCaseEvents =
-          caseFromCaseService
-              .getCaseEvents()
-              .stream()
-              .filter(e -> !e.getDescription().contains("Should be filtered out"))
-              .map(
-                  e ->
-                      CaseEventDTO.builder()
-                          .description(e.getDescription())
-                          .category(e.getEventType())
-                          .createdDateTime(e.getCreatedDateTime())
-                          .build())
-              .collect(Collectors.toList());
-      expectedCaseResult.setCaseEvents(expectedCaseEvents);
-    }
-    return expectedCaseResult;
-  }
-
-  @SneakyThrows
-  private void verifyCase(
-      CaseDTO results, CaseDTO expectedCaseResult, boolean caseEventsExpected, boolean cached) {
-    assertEquals(expectedCaseResult.getId(), results.getId());
-    assertEquals(expectedCaseResult.getCaseRef(), results.getCaseRef());
-    assertEquals(expectedCaseResult.getCaseType(), results.getCaseType());
-    assertEquals(expectedCaseResult.getCeOrgName(), results.getCeOrgName());
-    assertEquals(
-        expectedCaseResult.getAllowedDeliveryChannels(), results.getAllowedDeliveryChannels());
-
-    if (caseEventsExpected && cached) {
-      // Cached case doesn't have any events
-      assertTrue(results.getCaseEvents().isEmpty());
-    } else if (caseEventsExpected) {
-      // Note that the test data contains 3 events, but the 'X11' event is filtered out as it is not
-      // on the whitelist
-      assertEquals(2, results.getCaseEvents().size());
-      CaseEventDTO event = results.getCaseEvents().get(0);
-      assertEquals("Initial creation of case", event.getDescription());
-      assertEquals("CASE_CREATED", event.getCategory());
-      assertEquals(asMillis("2019-05-14T16:11:41.343+01:00"), event.getCreatedDateTime().getTime());
-      event = results.getCaseEvents().get(1);
-      assertEquals("Create Household Visit", event.getDescription());
-      assertEquals("CASE_UPDATED", event.getCategory());
-      assertEquals(asMillis("2019-05-16T12:12:12.343Z"), event.getCreatedDateTime().getTime());
-    } else {
-      assertNull(results.getCaseEvents());
-    }
-
-    assertEquals(expectedCaseResult, results);
-    Mockito.verify(dataRepo, never()).writeCachedCase(any());
-    Mockito.verify(addressSvc, never()).uprnQuery(anyLong());
-    verifyEventNotSent();
   }
 
   private List<CaseContainerDTO> casesFromCaseService() {

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
@@ -22,7 +22,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,7 +44,6 @@ import uk.gov.ons.ctp.common.event.model.NewAddress;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.client.addressindex.model.AddressIndexAddressCompositeDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
-import uk.gov.ons.ctp.integration.contactcentresvc.config.CaseServiceSettings;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseQueryRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.DeliveryChannel;
@@ -76,11 +74,7 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
 
   @Before
   public void setup() {
-    // For case retrieval, mock out a whitelist of allowable case events
-    CaseServiceSettings caseServiceSettings = new CaseServiceSettings();
-    Set<String> whitelistedSet = Set.of("CASE_CREATED", "CASE_UPDATED");
-    caseServiceSettings.setWhitelistedEventCategories(whitelistedSet);
-    when(appConfig.getCaseServiceSettings()).thenReturn(caseServiceSettings);
+    mockCaseEventWhiteList();
 
     when(appConfig.getChannel()).thenReturn(Channel.CC);
     when(appConfig.getSurveyName()).thenReturn(SURVEY_NAME);

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -1,6 +1,5 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
-import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -57,6 +56,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
 
   @Before
   public void setup() {
+    mockCaseEventWhiteList();
     requestDTO = FixtureHelper.loadClassFixtures(ModifyCaseRequestDTO[].class).get(0);
     caseContainerDTO = FixtureHelper.loadPackageFixtures(CaseContainerDTO[].class).get(0);
     cachedCase = FixtureHelper.loadPackageFixtures(CachedCase[].class).get(0);
@@ -431,18 +431,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   }
 
   private CachedCase createExpectedCachedCaseFromExistingRmCase(UUID id) {
-    List<CaseEventDTO> expectedCaseEvents =
-        caseContainerDTO
-            .getCaseEvents()
-            .stream()
-            .map(
-                ce ->
-                    CaseEventDTO.builder()
-                        .category(ce.getEventType())
-                        .description(ce.getDescription())
-                        .createdDateTime(ce.getCreatedDateTime())
-                        .build())
-            .collect(toList());
+    List<CaseEventDTO> expectedCaseEvents = filterEvents(caseContainerDTO);
 
     return CachedCase.builder()
         .id(id.toString())

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -86,17 +86,17 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   }
 
   private void verifyRmCaseCall(int times) {
-    verify(caseServiceClient, times(times)).getCaseById(any(), eq(false));
+    verify(caseServiceClient, times(times)).getCaseById(any(), eq(true));
   }
 
   private void mockRmHasCase() {
-    when(caseServiceClient.getCaseById(eq(UUID_0), eq(false))).thenReturn(caseContainerDTO);
+    when(caseServiceClient.getCaseById(eq(UUID_0), eq(true))).thenReturn(caseContainerDTO);
   }
 
   private void mockRmCannotFindCase() {
     ResponseStatusException rmLookupMockException =
         new ResponseStatusException(HttpStatus.NOT_FOUND);
-    when(caseServiceClient.getCaseById(eq(UUID_0), eq(false))).thenThrow(rmLookupMockException);
+    when(caseServiceClient.getCaseById(eq(UUID_0), eq(true))).thenThrow(rmLookupMockException);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -1,5 +1,6 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
@@ -13,7 +14,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_0;
 
-import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.Before;
@@ -425,11 +426,24 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
         .estabType(requestDTO.getEstabType().getCode())
         .region(cachedCase.getRegion())
         .ceOrgName(requestDTO.getCeOrgName())
-        .caseEvents(new ArrayList<CaseEventDTO>())
+        .caseEvents(cachedCase.getCaseEvents())
         .build();
   }
 
   private CachedCase createExpectedCachedCaseFromExistingRmCase(UUID id) {
+    List<CaseEventDTO> expectedCaseEvents =
+        caseContainerDTO
+            .getCaseEvents()
+            .stream()
+            .map(
+                ce ->
+                    CaseEventDTO.builder()
+                        .category(ce.getEventType())
+                        .description(ce.getDescription())
+                        .createdDateTime(ce.getCreatedDateTime())
+                        .build())
+            .collect(toList());
+
     return CachedCase.builder()
         .id(id.toString())
         .uprn(caseContainerDTO.getUprn())
@@ -445,7 +459,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
         .estabType(requestDTO.getEstabType().getCode())
         .region(caseContainerDTO.getRegion())
         .ceOrgName(requestDTO.getCeOrgName())
-        .caseEvents(new ArrayList<CaseEventDTO>())
+        .caseEvents(expectedCaseEvents)
         .build();
   }
 
@@ -563,6 +577,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
     assertEquals(caseContainerDTO.getUprn(), uprnStr(response.getUprn()));
     assertEquals(caseContainerDTO.getEstabUprn(), uprnStr(response.getEstabUprn()));
     assertEquals(ALL_DELIVERY_CHANNELS, response.getAllowedDeliveryChannels());
+    assertTrue(response.getCaseEvents().isEmpty());
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -16,6 +16,7 @@ import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
+import java.util.Set;
 import lombok.SneakyThrows;
 import ma.glasnost.orika.MapperFacade;
 import org.mockito.ArgumentCaptor;
@@ -37,6 +38,7 @@ import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerD
 import uk.gov.ons.ctp.integration.common.product.ProductReference;
 import uk.gov.ons.ctp.integration.contactcentresvc.CCSvcBeanMapper;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.AppConfig;
+import uk.gov.ons.ctp.integration.contactcentresvc.config.CaseServiceSettings;
 import uk.gov.ons.ctp.integration.contactcentresvc.repository.CaseDataRepository;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
@@ -153,7 +155,7 @@ public abstract class CaseServiceImplTestBase {
     return expectedCaseResult;
   }
 
-  private List<CaseEventDTO> filterEvents(CaseContainerDTO caseFromCaseService) {
+  List<CaseEventDTO> filterEvents(CaseContainerDTO caseFromCaseService) {
     return caseFromCaseService
         .getCaseEvents()
         .stream()
@@ -180,5 +182,12 @@ public abstract class CaseServiceImplTestBase {
     caseFromCaseService.setRegion(region);
     when(caseServiceClient.getCaseById(eq(UUID_0), any())).thenReturn(caseFromCaseService);
     return caseFromCaseService;
+  }
+
+  void mockCaseEventWhiteList() {
+    CaseServiceSettings caseServiceSettings = new CaseServiceSettings();
+    Set<String> whitelistedSet = Set.of("CASE_CREATED", "CASE_UPDATED");
+    caseServiceSettings.setWhitelistedEventCategories(whitelistedSet);
+    when(appConfig.getCaseServiceSettings()).thenReturn(caseServiceSettings);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Set;
-import lombok.SneakyThrows;
 import ma.glasnost.orika.MapperFacade;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
@@ -105,8 +104,8 @@ public abstract class CaseServiceImplTestBase {
     verify(dataRepo, never()).writeCachedCase(any());
   }
 
-  @SneakyThrows
-  void verifyCase(CaseDTO results, CaseDTO expectedCaseResult, boolean caseEventsExpected) {
+  void verifyCase(CaseDTO results, CaseDTO expectedCaseResult, boolean caseEventsExpected)
+      throws Exception {
     assertEquals(expectedCaseResult.getId(), results.getId());
     assertEquals(expectedCaseResult.getCaseRef(), results.getCaseRef());
     assertEquals(expectedCaseResult.getCaseType(), results.getCaseType());

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.CachedCase.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.CachedCase.json
@@ -14,7 +14,18 @@
     "estabType": "Household",
     "region": "E",
     "ceOrgName": "The Cached Case Organisation",
-    "caseEvents": []
+    "caseEvents": [
+      {
+        "category": "CASE_CREATED",
+        "description": "Cache: Initial creation of case",
+        "createdDateTime": "2020-05-14T16:11:41.343+01:00"
+      },
+      {
+        "category": "CASE_UPDATED",
+        "description": "Cache: Create Household Visit",
+        "createdDateTime": "2020-05-16T12:12:12.343Z"
+      }
+    ]
   },
   {
     "id": "c46e5dd4-4b17-45ac-a034-0e514e8592c0",
@@ -31,6 +42,12 @@
     "estabType": "Holiday Park",
     "region": "E",
     "ceOrgName": "The Cached Case Organisation",
-    "caseEvents": []
+    "caseEvents": [
+      {
+        "category": "CASE_CREATED",
+        "description": "Cache: Initial creation",
+        "createdDateTime": "2020-06-14T16:11:41.343+01:00"
+      }
+    ]
   }
 ]


### PR DESCRIPTION
# Motivation and Context
- Previously, all cached cases in firestore had empty caseEvents, now CR-1111 requires that caseEvents are stored in the cachedCases, as retrieved (and filtered) from RM.
- a bug with the PUT (modify) endpoint has been fixed where the createdDateTime was not being updated.
- endpoints returning cachedCase information have been updated to ensure caseEvents are returned when required.

NOTE: there is a minor cucumber change that goes with this for testing empty caseEvents. This needs to be merged at the same time as the cucumber PR.

# What has changed
- as agreed with @philwhiles , filtering of caseEvents has been done early after retrieval from RM. This assists the implementation of this feature.
- As agreed with @philwhiles  , all CaseDTO and cachedCase caseEvents will always be populated with non-null value, even if empty. This assists best practice coding for avoiding nulls for retrieving collections, and corrects previous inconsistent behaviour
- tests have been altered to ensure we check all caseEvents correctly
- some duplication of code in the tests has been centralised for verifying cases.

# How to test?
- unit tests
- cucumber tests
- Postman, in particular:
   - add a  case to the mock-case service
  - ensure it is retrieved correctly by all endpoints (get by ID, UPRN and caseRef) with caseEvents=true, with correct event whitelist filtering
  - do PUT modify operation and check the updated information is stored in firestore
  - ensure the changes as made by PUT modify operation and correctly retried by the get by ID, UPRN and caseRef with caseEvents = true, with correct whitelist filtering.

