### PR TITLE
Cr 1114 unrestricted agent

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.124</version>
+      <version>0.0.125-SNAPSHOT</version>
     </dependency>
 
     <!--

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.125-SNAPSHOT</version>
+      <version>0.0.125</version>
     </dependency>
 
     <!--

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -709,7 +709,7 @@ public class CaseServiceImpl implements CaseService {
               uk.gov.ons.ctp.common.domain.Source.CONTACT_CENTRE_API,
               uk.gov.ons.ctp.common.domain.Channel.CC,
               caseDetails,
-              requestParamsDTO.getAgentId(),
+              Integer.toString(requestParamsDTO.getAgentId()),
               questionnaireId,
               formType,
               null,
@@ -763,7 +763,7 @@ public class CaseServiceImpl implements CaseService {
     return response;
   }
 
-  private void publishSurveyLaunchedEvent(UUID caseId, String questionnaireId, String agentId) {
+  private void publishSurveyLaunchedEvent(UUID caseId, String questionnaireId, Integer agentId) {
     log.with("questionnaireId", questionnaireId)
         .with("caseId", caseId)
         .with("agentId", agentId)
@@ -773,7 +773,7 @@ public class CaseServiceImpl implements CaseService {
         SurveyLaunchedResponse.builder()
             .questionnaireId(questionnaireId)
             .caseId(caseId)
-            .agentId(agentId)
+            .agentId(Integer.toString(agentId))
             .build();
 
     sendEvent(EventType.SURVEY_LAUNCHED, response, response.getCaseId());
@@ -976,7 +976,7 @@ public class CaseServiceImpl implements CaseService {
     refusal.setType(mapToType(refusalRequest.getReason()));
     CollectionCaseCompact collectionCase = new CollectionCaseCompact(caseId);
     refusal.setCollectionCase(collectionCase);
-    refusal.setAgentId(refusalRequest.getAgentId());
+    refusal.setAgentId(Integer.toString(refusalRequest.getAgentId()));
     refusal.setCallId(refusalRequest.getCallId());
     refusal.setHouseholder(refusalRequest.getIsHouseholder());
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.java
@@ -264,7 +264,7 @@ public final class CaseEndpointRefusalTest {
 
   @Test
   public void refusalAgentIdTooLong() throws Exception {
-    assertBadRequest(AGENT_ID, "123456");
+    assertBadRequest(AGENT_ID, "9" + Integer.MAX_VALUE);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
@@ -149,7 +149,7 @@ public abstract class EndpointSecurityTest {
     RefusalRequestDTO requestBody = new RefusalRequestDTO();
     requestBody.setCaseId(caseId.toString());
     requestBody.setReason(Reason.HARD);
-    requestBody.setAgentId("12345");
+    requestBody.setAgentId(12345);
     requestBody.setCallId("8989-NOW");
     requestBody.setIsHouseholder(false);
     requestBody.setDateTime(new Date());

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplReportRefusalTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplReportRefusalTest.java
@@ -97,7 +97,7 @@ public class CaseServiceImplReportRefusalTest extends CaseServiceImplTestBase {
     RefusalRequestDTO refusalPayload =
         RefusalRequestDTO.builder()
             .caseId(caseId == null ? null : caseId.toString())
-            .agentId("123")
+            .agentId(123)
             .title("Mr")
             .forename("Steve")
             .surname("Jones")


### PR DESCRIPTION
# Motivation and Context
Following on from the **agentId** changes from string to integer in CC-API, changes are necessary here to fit.

Note that the **agentId** in the event publisher objects by agreement remain as strings.

See JIRA CR-1114.

This needs to merged at the same time as the CC-cuc PR https://github.com/ONSdigital/census-contact-centre-cucumber/pull/59