### PR TITLE
Cr 1160 removed unknown from refusuals endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.125</version>
+      <version>0.0.126-SNAPSHOT-CR1160</version>
     </dependency>
 
     <!-- WARNING WARNING WARNING The CCCucmber project has this dependancy 

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.126-SNAPSHOT</version>
+      <version>0.0.126</version>
     </dependency>
 
     <!-- WARNING WARNING WARNING The CCCucmber project has this dependancy 

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.126-SNAPSHOT-CR1160</version>
+      <version>0.0.126-SNAPSHOT</version>
     </dependency>
 
     <!-- WARNING WARNING WARNING The CCCucmber project has this dependancy 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
@@ -8,7 +8,6 @@ import java.util.UUID;
 import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
-import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -211,9 +210,9 @@ public class CaseEndpoint implements CTPEndpoint {
   }
 
   /**
-   * the POST end point to report a refusal - caseId may be "unknown"
+   * the POST end point to report a refusal.
    *
-   * @param caseId is the case to log the refusal against. May contain 'unknown'.
+   * @param caseId is the case to log the refusal against.
    * @param requestBodyDTO the request body.
    * @return response entity
    * @throws CTPException something went wrong
@@ -221,7 +220,7 @@ public class CaseEndpoint implements CTPEndpoint {
   @RequestMapping(value = "/{caseId}/refusal", method = RequestMethod.POST)
   @ResponseStatus(value = HttpStatus.OK)
   public ResponseEntity<ResponseDTO> reportRefusal(
-      @PathVariable(value = "caseId") final String caseId,
+      @PathVariable(value = "caseId") final UUID caseId,
       @Valid @RequestBody RefusalRequestDTO requestBodyDTO)
       throws CTPException {
 
@@ -229,23 +228,13 @@ public class CaseEndpoint implements CTPEndpoint {
         .with("requestBody", requestBodyDTO)
         .info("Entering POST reportRefusal");
 
-    UUID caseIdUUID = null;
-    if (StringUtils.isBlank(caseId)) {
-      log.with("caseId", caseId).warn("reportRefusal caseId must be a valid UUID or \"UNKNOWN\"");
-      throw new CTPException(Fault.BAD_REQUEST, "caseId must be a valid UUID or \"UNKNOWN\"");
-    } else if (!caseId.equals(requestBodyDTO.getCaseId())) {
+    if (!caseId.equals(requestBodyDTO.getCaseId())) {
       log.with("caseId", caseId).warn("reportRefusal caseId in path and body must be identical");
       throw new CTPException(
           Fault.BAD_REQUEST, "reportRefusal caseId in path and body must be identical");
-    } else if (!caseId.toUpperCase().equals("UNKNOWN")) {
-      try {
-        caseIdUUID = UUID.fromString(caseId);
-      } catch (IllegalArgumentException e) {
-        log.with("caseId", caseId).warn("reportRefusal caseId must be a valid UUID");
-        throw new CTPException(Fault.BAD_REQUEST, "caseId must be a valid UUID");
-      }
     }
-    ResponseDTO response = caseService.reportRefusal(caseIdUUID, requestBodyDTO);
+
+    ResponseDTO response = caseService.reportRefusal(caseId, requestBodyDTO);
 
     log.with("caseId", caseId).debug("Exiting reportRefusal");
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
 import static java.util.stream.Collectors.toList;
-import static uk.gov.ons.ctp.integration.contactcentresvc.utility.Constants.UNKNOWN_UUID;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
@@ -538,10 +537,7 @@ public class CaseServiceImpl implements CaseService {
 
     // Build response
     ResponseDTO response =
-        ResponseDTO.builder()
-            .id(caseId == null ? UNKNOWN_UUID : caseId.toString())
-            .dateTime(DateTimeUtil.nowUTC())
-            .build();
+        ResponseDTO.builder().id(caseId.toString()).dateTime(DateTimeUtil.nowUTC()).build();
 
     log.with("caseId", caseId).debug("Returning refusal response for case");
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -531,9 +531,8 @@ public class CaseServiceImpl implements CaseService {
         .debug("Processing refusal for case with reported dateTime");
 
     // Create and publish a respondent refusal event
-    UUID refusalCaseId = caseId == null ? new UUID(0, 0) : caseId;
     RespondentRefusalDetails refusalPayload =
-        createRespondentRefusalPayload(refusalCaseId, requestBodyDTO);
+        createRespondentRefusalPayload(caseId, requestBodyDTO);
 
     sendEvent(EventType.REFUSAL_RECEIVED, refusalPayload, caseId);
 

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/utility/Constants.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/utility/Constants.java
@@ -1,6 +1,0 @@
-package uk.gov.ons.ctp.integration.contactcentresvc.utility;
-
-/** Constants used across the service */
-public class Constants {
-  public static final String UNKNOWN_UUID = "unknown";
-}

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointRefusalTest.java
@@ -84,11 +84,12 @@ public final class CaseEndpointRefusalTest {
   }
 
   @Test
-  public void refusalGoodBodyCaseIdBothUnknown() throws Exception {
+  public void refusalForUnknownCaseFails() throws Exception {
+    // Refusals no longer supports an 'unknown' case
     ObjectNode json = FixtureHelper.loadClassObjectNode();
     json.put(CASE_ID, "unknown");
     ResultActions actions = mockMvc.perform(postJson("/cases/unknown/refusal", json.toString()));
-    actions.andExpect(status().isOk());
+    actions.andExpect(status().isBadRequest());
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
@@ -147,7 +147,7 @@ public abstract class EndpointSecurityTest {
   void testPostRefusal(HttpStatus expectedStatus) {
     UUID caseId = UUID.randomUUID();
     RefusalRequestDTO requestBody = new RefusalRequestDTO();
-    requestBody.setCaseId(caseId.toString());
+    requestBody.setCaseId(caseId);
     requestBody.setReason(Reason.HARD);
     requestBody.setAgentId(12345);
     requestBody.setCallId("8989-NOW");

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplReportRefusalTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplReportRefusalTest.java
@@ -73,19 +73,6 @@ public class CaseServiceImplReportRefusalTest extends CaseServiceImplTestBase {
         caseId, expectedEventCaseId, expectedResponseCaseId, dateTime, Reason.EXTRAORDINARY);
   }
 
-  @Test
-  public void testRespondentRefusal_forUnknownUUID() throws Exception {
-    UUID unknownCaseId = null;
-    UUID expectedEventCaseId = UUID.fromString("00000000-0000-0000-0000-000000000000");
-    String expectedResponseCaseId = "unknown";
-    doRespondentRefusalTest(
-        unknownCaseId,
-        expectedEventCaseId,
-        expectedResponseCaseId,
-        new Date(),
-        Reason.EXTRAORDINARY);
-  }
-
   private void doRespondentRefusalTest(
       UUID caseId,
       UUID expectedEventCaseId,
@@ -96,7 +83,7 @@ public class CaseServiceImplReportRefusalTest extends CaseServiceImplTestBase {
     UniquePropertyReferenceNumber uprn = new UniquePropertyReferenceNumber(A_UPRN);
     RefusalRequestDTO refusalPayload =
         RefusalRequestDTO.builder()
-            .caseId(caseId == null ? null : caseId.toString())
+            .caseId(caseId)
             .agentId(123)
             .title("Mr")
             .forename("Steve")


### PR DESCRIPTION
Changes:

- Deleted code which supported the 'unknown' case in the refusals endpoint.
- Changed caseId in the request to an actual UUID object instead of a String.
- Updated unit tests.