### PR TITLE
Cr 1065 play firestore events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.42</version>
+      <version>0.0.43-CR1065-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>event-publisher</artifactId>
-      <version>0.0.43-CR1065-SNAPSHOT</version>
+      <version>0.0.43</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Just a pom update.

Ensure the latest version of event publisher is used, so there is no chance that out-of-date event structures are stored in firestore.

Tests pass in DEV.