### PR TITLE
CR-1208 | Pointing to the new release version of census-int-common-service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.126</version>
+      <version>0.0.127</version>
     </dependency>
 
     <!-- WARNING WARNING WARNING The CCCucmber project has this dependancy

--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>framework</artifactId>
-      <version>0.0.65</version>
+      <version>0.0.66</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -126,7 +126,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.127</version>
+      <version>0.0.126</version>
     </dependency>
 
     <!-- WARNING WARNING WARNING The CCCucmber project has this dependancy

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/EndpointSecurityTest.java
@@ -137,7 +137,7 @@ public abstract class EndpointSecurityTest {
     requestBody.setTownName("Coronaville");
     requestBody.setPostcode("SO22 4HJ");
     requestBody.setRegion(Region.E);
-    requestBody.setEstabType(EstabType.GATED_APARTMENTS);
+    requestBody.setEstabType(EstabType.RESIDENTIAL_BOAT);
 
     ResponseEntity<String> response =
         restTemplate.postForEntity(base.toString() + "/cases", requestBody, String.class);

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
@@ -229,7 +229,7 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
 
       // We need to account for the mapping from a CachedCase to a CaseDTO missing a few fields:
       expectedCaseResult.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
-      expectedCaseResult.setEstabType(EstabType.HOLIDAY_PARK);
+      expectedCaseResult.setEstabType(EstabType.CARE_HOME);
       if (!caseEvents) {
         expectedCaseResult.setCaseEvents(Collections.emptyList());
       }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -75,7 +75,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldRejectIncompatibleCaseTypeAndEstabType() {
     verifyRejectIncompatible(EstabType.APPROVED_PREMISES, CaseType.HH);
-    verifyRejectIncompatible(EstabType.IMMIGRATION_REMOVAL_CENTRE, CaseType.CE);
+    verifyRejectIncompatible(EstabType.RESIDENTIAL_BOAT, CaseType.CE);
     verifyRmCaseCall(0);
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -205,7 +205,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   }
 
   @Test
-  public void shouldModifyAddress_RequestHH_ExistingCastleHH() throws Exception {
+  public void shouldModifyAddress_RequestHH_ExistingResidentialBoatHH() throws Exception {
     verifyModifyAddress(CaseType.HH, EstabType.HOUSEHOLD, EstabType.RESIDENTIAL_BOAT.getCode());
   }
 
@@ -225,7 +225,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   }
 
   @Test
-  public void shouldModifyAddress_RequestSPG_ExistingCastleHH() throws Exception {
+  public void shouldModifyAddress_RequestSPG_ExistingMilitarySfaHH() throws Exception {
     verifyModifyAddress(CaseType.SPG, EstabType.EMBASSY, EstabType.MILITARY_SFA.getCode());
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -75,7 +75,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldRejectIncompatibleCaseTypeAndEstabType() {
     verifyRejectIncompatible(EstabType.APPROVED_PREMISES, CaseType.HH);
-    verifyRejectIncompatible(EstabType.FOREIGN_OFFICES, CaseType.CE);
+    verifyRejectIncompatible(EstabType.IMMIGRATION_REMOVAL_CENTRE, CaseType.CE);
     verifyRmCaseCall(0);
   }
 
@@ -104,7 +104,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   public void shouldAcceptCompatibleCaseTypeAndEstabType() throws Exception {
     mockRmHasCase();
     verifyAcceptCompatible(EstabType.APPROVED_PREMISES, CaseType.CE);
-    verifyAcceptCompatible(EstabType.FOREIGN_OFFICES, CaseType.HH);
+    verifyAcceptCompatible(EstabType.RESIDENTIAL_BOAT, CaseType.HH);
     verifyRmCaseCall(2);
   }
 
@@ -206,7 +206,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
 
   @Test
   public void shouldModifyAddress_RequestHH_ExistingCastleHH() throws Exception {
-    verifyModifyAddress(CaseType.HH, EstabType.HOUSEHOLD, EstabType.CASTLES.getCode());
+    verifyModifyAddress(CaseType.HH, EstabType.HOUSEHOLD, EstabType.RESIDENTIAL_BOAT.getCode());
   }
 
   @Test
@@ -226,7 +226,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
 
   @Test
   public void shouldModifyAddress_RequestSPG_ExistingCastleHH() throws Exception {
-    verifyModifyAddress(CaseType.SPG, EstabType.EMBASSY, EstabType.CASTLES.getCode());
+    verifyModifyAddress(CaseType.SPG, EstabType.EMBASSY, EstabType.MILITARY_SFA.getCode());
   }
 
   @Test
@@ -241,7 +241,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
 
   @Test
   public void shouldModifyAddress_RequestCE_ExistingPrisonCE() throws Exception {
-    verifyModifyAddress(CaseType.CE, EstabType.HOLIDAY_PARK, "prison");
+    verifyModifyAddress(CaseType.CE, EstabType.CARE_HOME, "prison");
   }
 
   @Test
@@ -331,13 +331,13 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldChangeAddressType_RequestCE_ExistingHousehold() throws Exception {
     verifyAddressTypeChanged(
-        CaseType.CE, EstabType.HOLIDAY_PARK, EstabType.HOUSEHOLD.getCode(), CaseType.HH);
+        CaseType.CE, EstabType.CARE_HOME, EstabType.HOUSEHOLD.getCode(), CaseType.HH);
   }
 
   @Test
   public void shouldChangeAddressType_RequestCE_ExistingEmbassySPG() throws Exception {
     verifyAddressTypeChanged(
-        CaseType.CE, EstabType.HOLIDAY_PARK, EstabType.EMBASSY.getCode(), CaseType.SPG);
+        CaseType.CE, EstabType.CARE_HOME, EstabType.EMBASSY.getCode(), CaseType.SPG);
   }
 
   @Test
@@ -347,14 +347,13 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
 
   @Test
   public void shouldChangeAddressType_RequestCE_ExistingOtherSPG() throws Exception {
-    verifyAddressTypeChanged(
-        CaseType.CE, EstabType.HOLIDAY_PARK, "Oblivion Sky Tower", CaseType.SPG);
+    verifyAddressTypeChanged(CaseType.CE, EstabType.CARE_HOME, "Oblivion Sky Tower", CaseType.SPG);
   }
 
   @Test
   public void shouldRejectNorthernIrelandChangeFromHouseholdToCE() {
     requestDTO.setCaseType(CaseType.CE);
-    requestDTO.setEstabType(EstabType.HOLIDAY_PARK);
+    requestDTO.setEstabType(EstabType.CARE_HOME);
     caseContainerDTO.setEstabType(EstabType.HOUSEHOLD.getCode());
     caseContainerDTO.setCaseType(CaseType.HH.name());
     caseContainerDTO.setRegion(Region.N.name());
@@ -369,7 +368,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldNotRejectNorthernIrelandChangeWhenNotInNorthernIreland() throws Exception {
     requestDTO.setCaseType(CaseType.CE);
-    requestDTO.setEstabType(EstabType.HOLIDAY_PARK);
+    requestDTO.setEstabType(EstabType.CARE_HOME);
     caseContainerDTO.setEstabType(EstabType.HOUSEHOLD.getCode());
     caseContainerDTO.setCaseType(CaseType.HH.name());
     caseContainerDTO.setRegion(Region.E.name());
@@ -403,7 +402,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldNotRejectNorthernIrelandChangeWhenNotExistingHouseHold() throws Exception {
     requestDTO.setCaseType(CaseType.CE);
-    requestDTO.setEstabType(EstabType.HOLIDAY_PARK);
+    requestDTO.setEstabType(EstabType.CARE_HOME);
     caseContainerDTO.setEstabType(EstabType.EMBASSY.getCode());
     caseContainerDTO.setCaseType(CaseType.SPG.name());
     caseContainerDTO.setRegion(Region.N.name());
@@ -515,7 +514,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldSaveCachedCaseWhenAddressTypeChanged() throws Exception {
     requestDTO.setCaseType(CaseType.CE);
-    requestDTO.setEstabType(EstabType.HOLIDAY_PARK);
+    requestDTO.setEstabType(EstabType.CARE_HOME);
     caseContainerDTO.setEstabType(EstabType.EMBASSY.getCode());
     mockRmHasCase();
     CaseDTO response = target.modifyCase(requestDTO);
@@ -529,7 +528,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldUpdateCachedCaseWhenAddressTypeChanged() throws Exception {
     requestDTO.setCaseType(CaseType.CE);
-    requestDTO.setEstabType(EstabType.HOLIDAY_PARK);
+    requestDTO.setEstabType(EstabType.CARE_HOME);
     caseContainerDTO.setEstabType(EstabType.EMBASSY.getCode());
 
     mockRmCannotFindCase();
@@ -613,7 +612,7 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldReturnModifiedCaseWhenAddressTypeChanged() throws Exception {
     requestDTO.setCaseType(CaseType.CE);
-    requestDTO.setEstabType(EstabType.HOLIDAY_PARK);
+    requestDTO.setEstabType(EstabType.CARE_HOME);
     caseContainerDTO.setEstabType(EstabType.EMBASSY.getCode());
     mockRmHasCase();
     CaseDTO response = target.modifyCase(requestDTO);

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.CachedCase.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.CachedCase.json
@@ -39,7 +39,7 @@
     "postcode": "EX1 2ET",
     "addressType": "CE",
     "caseType": "CE",
-    "estabType": "Holiday Park",
+    "estabType": "Care Home",
     "region": "E",
     "ceOrgName": "The Cached Case Organisation",
     "caseEvents": [


### PR DESCRIPTION
The EstabType has been update in census-int-common-service and also OTHER type has been modified to fix an existing bug. A new version of census-int-common-service has been released which is 0.0.66. Updating pom.xml to point to this new version.

Also some tests have been updated as they were using the EstabTypes which do not exist anymore after the update to the EstabType enum.

For more details on the changes in census-int-common-service please have a look at https://collaborate2.ons.gov.uk/jira/browse/CR-1208.