### PR TITLE
CR-1071 fix corner-case bug for HARD refusal with missing contact ele…

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1030,6 +1030,9 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private String encrypt(String clearValue) {
+    if (clearValue == null) {
+      return null;
+    }
     List<Resource> keys = List.of(appConfig.getPublicPgpKey1(), appConfig.getPublicPgpKey2());
     String encStr = PgpEncrypt.encrypt(clearValue, keys);
     return Base64.getEncoder().encodeToString(encStr.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
If some contact details are missing (or null) for a HARD refusal, then the encryption introduced in CR-1071 will fail.

I have discussed with @philwhiles and agreed to null those missing fields when doing the refusal.

This code fixes that bug.
