### PR TITLE
CR-1202 Address type changed comparison

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -388,9 +388,7 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private boolean isCaseTypeChange(CaseType requestedCaseType, CaseType existingCaseType) {
-    boolean requestCE = CaseType.CE == requestedCaseType;
-    boolean existingCE = CaseType.CE == existingCaseType;
-    return requestCE ^ existingCE;
+    return requestedCaseType != existingCaseType;
   }
 
   private void rejectNorthernIrelandHouseholdToCE(

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -215,11 +215,6 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   }
 
   @Test
-  public void shouldModifyAddress_RequestHH_ExistingOtherNull() throws Exception {
-    verifyModifyAddress(CaseType.HH, EstabType.HOUSEHOLD, "Oblivion Sky Tower", CaseType.SPG);
-  }
-
-  @Test
   public void shouldModifyAddress_RequestSPG_ExistingHouseHold() throws Exception {
     verifyModifyAddress(CaseType.SPG, EstabType.EMBASSY, EstabType.HOUSEHOLD.getCode());
   }
@@ -232,11 +227,6 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldModifyAddress_RequestSPG_ExistingEmbassySPG() throws Exception {
     verifyModifyAddress(CaseType.SPG, EstabType.EMBASSY, EstabType.EMBASSY.getCode());
-  }
-
-  @Test
-  public void shouldModifyAddress_RequestSPG_ExistingOtherNull() throws Exception {
-    verifyModifyAddress(CaseType.SPG, EstabType.EMBASSY, "Oblivion Sky Tower", CaseType.HH);
   }
 
   @Test
@@ -348,6 +338,16 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   @Test
   public void shouldChangeAddressType_RequestCE_ExistingOtherSPG() throws Exception {
     verifyAddressTypeChanged(CaseType.CE, EstabType.CARE_HOME, "Oblivion Sky Tower", CaseType.SPG);
+  }
+
+  @Test
+  public void shouldChangeAddressType_RequestSPG_ExistingOtherNull() throws Exception {
+    verifyAddressTypeChanged(CaseType.SPG, EstabType.EMBASSY, "Oblivion Sky Tower", CaseType.HH);
+  }
+
+  @Test
+  public void shouldChangeAddressType_RequestHH_ExistingOtherNull() throws Exception {
+    verifyAddressTypeChanged(CaseType.HH, EstabType.HOUSEHOLD, "Oblivion Sky Tower", CaseType.SPG);
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
Send an address type changed event for a change of HH to SPG or vice versa. Previously sent address changed event.

# What has changed
CaseServiceImpl  removal of xor operator logic and replaced with simple comparison of requested CaseType to existing CaseType.

# How to test?
Unittests amended for HH and SPG change.   
Cucumber tests run for contact centre service.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1201
