### PR TITLE
CR-1247 modify cloud logback config so it doesn't omit log entries

### DIFF
--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,3 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xml>
 <configuration>
   <include
     resource="org/springframework/boot/logging/logback/defaults.xml" />
@@ -59,14 +61,8 @@
         <nestedField>
           <fieldName>data</fieldName>
           <providers>
-            <arguments>
-              <includeNonStructuredArguments>true
-              </includeNonStructuredArguments>
-              <nonStructuredArgumentsFieldPrefix>prefix
-              </nonStructuredArgumentsFieldPrefix>
-            </arguments>
-        <tags />
-        <logstashMarkers />
+            <tags />
+            <logstashMarkers />
           </providers>
         </nestedField>
       </providers>


### PR DESCRIPTION
This change replicates the minor changes to RH Svc logback.xml (already merged) to prevent the omission of certain logging entries in the CLOUD profile.