### PR TITLE
Cr 744 - create endpoint to allow Serco staff to search for a CCS case by postcode

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-case-api-client</artifactId>
-      <version>0.0.18</version>
+      <version>0.0.19-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>census-int-case-api-client</artifactId>
-      <version>0.0.19-SNAPSHOT</version>
+      <version>0.0.19</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSPostcodesBean.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSPostcodesBean.java
@@ -2,12 +2,10 @@ package uk.gov.ons.ctp.integration.contactcentresvc;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
+import java.io.BufferedReader;
+import java.io.FileReader;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -31,13 +29,10 @@ public class CCSPostcodesBean {
     this.ccsPostcodes = new HashSet<>();
     String strPostcodePath = appConfig.getCcsPostcodes().getCcsPostcodePath();
 
-    Path postcodeFilePath = Paths.get(strPostcodePath);
-    List<String> postcodes;
-    try {
-      postcodes = Files.readAllLines(postcodeFilePath);
-      for (String postcode : postcodes) {
-        postcode = postcode.trim();
-        ccsPostcodes.add(postcode);
+    try (BufferedReader br = new BufferedReader(new FileReader(strPostcodePath))) {
+      String postcode;
+      while ((postcode = br.readLine()) != null) {
+        ccsPostcodes.add(postcode.trim());
       }
     } catch (IOException e) {
       log.with(strPostcodePath)

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSPostcodesBean.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSPostcodesBean.java
@@ -1,0 +1,49 @@
+package uk.gov.ons.ctp.integration.contactcentresvc;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import uk.gov.ons.ctp.integration.contactcentresvc.config.AppConfig;
+
+@Component
+public class CCSPostcodesBean {
+  private static final Logger log = LoggerFactory.getLogger(CCSPostcodesBean.class);
+
+  @Autowired
+  private AppConfig appConfig;
+
+  private Set<String> ccsPostcodes;
+
+  public boolean isInCCSPostcodes(String postcode) {
+    return ccsPostcodes.contains(postcode);
+  }
+
+  @PostConstruct
+  private void init() {
+    this.ccsPostcodes = new HashSet<>();
+    String strPostcodePath = appConfig.getCcsPostcodes().getCcsPostcodePath();
+
+    Path postcodeFilePath = Paths.get(strPostcodePath);
+    List<String> postcodes;
+    try {
+      postcodes = Files.readAllLines(postcodeFilePath);
+      for (String postcode : postcodes) {
+        postcode = postcode.trim();
+        ccsPostcodes.add(postcode);
+      }
+    } catch (IOException e) {
+      log.with(strPostcodePath).error("APPLICATION IS MISCONFIGURED - unable to read in postcodes from file."
+          + " Using postcodes from application.yml instead.", e);
+      ccsPostcodes = appConfig.getCcsPostcodes().getCcsDefaultPostcodes();
+    }
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSPostcodesBean.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/CCSPostcodesBean.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ctp.integration.contactcentresvc;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -10,16 +12,13 @@ import java.util.Set;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.AppConfig;
 
 @Component
 public class CCSPostcodesBean {
   private static final Logger log = LoggerFactory.getLogger(CCSPostcodesBean.class);
 
-  @Autowired
-  private AppConfig appConfig;
+  @Autowired private AppConfig appConfig;
 
   private Set<String> ccsPostcodes;
 
@@ -41,8 +40,11 @@ public class CCSPostcodesBean {
         ccsPostcodes.add(postcode);
       }
     } catch (IOException e) {
-      log.with(strPostcodePath).error("APPLICATION IS MISCONFIGURED - unable to read in postcodes from file."
-          + " Using postcodes from application.yml instead.", e);
+      log.with(strPostcodePath)
+          .error(
+              "APPLICATION IS MISCONFIGURED - unable to read in postcodes from file."
+                  + " Using postcodes from application.yml instead.",
+              e);
       ccsPostcodes = appConfig.getCcsPostcodes().getCcsDefaultPostcodes();
     }
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AppConfig.java
@@ -25,6 +25,7 @@ public class AppConfig {
   private Channel channel;
   private Resource publicPgpKey1;
   private Resource publicPgpKey2;
+  private CCSPostcodes ccsPostcodes;
 
   public void setChannel(Channel channel) {
     if (channel.equals(Channel.CC) || channel.equals(Channel.AD)) {

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
@@ -1,0 +1,13 @@
+package uk.gov.ons.ctp.integration.contactcentresvc.config;
+
+import java.util.Set;
+import lombok.Data;
+
+@Data
+public class CCSPostcodes {
+  private Set<String> ccsPostcodesToCheck;
+
+  public boolean isInCCSPostcodes(String postcode) {
+    return ccsPostcodesToCheck.contains(postcode);
+  }
+}

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
@@ -1,47 +1,10 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.config;
 
-import com.godaddy.logging.Logger;
-import com.godaddy.logging.LoggerFactory;
 import java.util.Set;
 import lombok.Data;
 
-// import java.io.IOException;
-// import java.nio.file.Files;
-// import java.nio.file.Path;
-// import java.nio.file.Paths;
-// import java.util.HashSet;
-// import java.util.List;
-
 @Data
 public class CCSPostcodes {
-  private static final Logger log = LoggerFactory.getLogger(CCSPostcodes.class);
-  private Set<String> ccsPostcodesToCheck;
   private String ccsPostcodePath;
-
-  public boolean isInCCSPostcodes(String postcode) {
-    // readInPostcodes();
-    return ccsPostcodesToCheck.contains(postcode);
-  }
-
-  // private void readInPostcodes() {
-  // Set<String> ccsPostcodes = new HashSet<>();
-  //
-  // List<String> postcodes;
-  // Path postcodeFilePath;
-  // postcodeFilePath = Paths.get(this.ccsPostcodePath);
-  // try {
-  // postcodes = Files.readAllLines(postcodeFilePath);
-  // for (String postcode : postcodes) {
-  // postcode = postcode.trim();
-  // ccsPostcodes.add(postcode);
-  // }
-  // this.ccsPostcodesToCheck = ccsPostcodes;
-  // } catch (IOException e) {
-  // log.with(this.ccsPostcodePath)
-  // .warn(
-  // "IOException caught as unable to read in postcodes from file."
-  // + " Using postcodes from application.yml instead.",
-  // e);
-  // }
-  // }
+  private Set<String> ccsPostcodesToCheck;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
@@ -1,13 +1,43 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.config;
 
+import com.godaddy.logging.Logger;
+import com.godaddy.logging.LoggerFactory;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import lombok.Data;
 
 @Data
 public class CCSPostcodes {
+  private static final Logger log = LoggerFactory.getLogger(CCSPostcodes.class);
   private Set<String> ccsPostcodesToCheck;
+  private String ccsPostcodePath;
 
   public boolean isInCCSPostcodes(String postcode) {
+    readInPostcodes();
     return ccsPostcodesToCheck.contains(postcode);
+  }
+
+  private void readInPostcodes() {
+    Set<String> ccsPostcodes = new HashSet<>();
+
+    List<String> postcodes;
+    try {
+      postcodes = Files.readAllLines(Paths.get(this.ccsPostcodePath));
+      for (String postcode : postcodes) {
+        postcode = postcode.trim();
+        ccsPostcodes.add(postcode);
+      }
+      this.ccsPostcodesToCheck = ccsPostcodes;
+    } catch (IOException e) {
+      log.with(this.ccsPostcodePath)
+          .warn(
+              "IOException caught as unable to read in postcodes from file."
+                  + " Using postcodes from application.yml instead.",
+              e);
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
@@ -2,13 +2,15 @@ package uk.gov.ons.ctp.integration.contactcentresvc.config;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import lombok.Data;
+
+// import java.io.IOException;
+// import java.nio.file.Files;
+// import java.nio.file.Path;
+// import java.nio.file.Paths;
+// import java.util.HashSet;
+// import java.util.List;
 
 @Data
 public class CCSPostcodes {
@@ -17,27 +19,29 @@ public class CCSPostcodes {
   private String ccsPostcodePath;
 
   public boolean isInCCSPostcodes(String postcode) {
-    readInPostcodes();
+    // readInPostcodes();
     return ccsPostcodesToCheck.contains(postcode);
   }
 
-  private void readInPostcodes() {
-    Set<String> ccsPostcodes = new HashSet<>();
-
-    List<String> postcodes;
-    try {
-      postcodes = Files.readAllLines(Paths.get(this.ccsPostcodePath));
-      for (String postcode : postcodes) {
-        postcode = postcode.trim();
-        ccsPostcodes.add(postcode);
-      }
-      this.ccsPostcodesToCheck = ccsPostcodes;
-    } catch (IOException e) {
-      log.with(this.ccsPostcodePath)
-          .warn(
-              "IOException caught as unable to read in postcodes from file."
-                  + " Using postcodes from application.yml instead.",
-              e);
-    }
-  }
+  // private void readInPostcodes() {
+  // Set<String> ccsPostcodes = new HashSet<>();
+  //
+  // List<String> postcodes;
+  // Path postcodeFilePath;
+  // postcodeFilePath = Paths.get(this.ccsPostcodePath);
+  // try {
+  // postcodes = Files.readAllLines(postcodeFilePath);
+  // for (String postcode : postcodes) {
+  // postcode = postcode.trim();
+  // ccsPostcodes.add(postcode);
+  // }
+  // this.ccsPostcodesToCheck = ccsPostcodes;
+  // } catch (IOException e) {
+  // log.with(this.ccsPostcodePath)
+  // .warn(
+  // "IOException caught as unable to read in postcodes from file."
+  // + " Using postcodes from application.yml instead.",
+  // e);
+  // }
+  // }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/CCSPostcodes.java
@@ -6,5 +6,5 @@ import lombok.Data;
 @Data
 public class CCSPostcodes {
   private String ccsPostcodePath;
-  private Set<String> ccsPostcodesToCheck;
+  private Set<String> ccsDefaultPostcodes;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
@@ -308,14 +308,8 @@ public class CaseEndpoint implements CTPEndpoint {
     return ResponseEntity.ok(response);
   }
 
-  // ---------------------------------------------------------------
-  // DUMMY ENDPOINTS FROM HERE
-  // ---------------------------------------------------------------
-
   /**
-   * DUMMY ENDPOINT FOR CC
-   *
-   * <p>the GET end point to request a CCS case by postcode
+   * the GET end point to request a CCS case by postcode
    *
    * @param postcode postcode
    * @return response entity
@@ -330,9 +324,14 @@ public class CaseEndpoint implements CTPEndpoint {
 
     log.with("pathParam", postcode).info("Entering GET getCCSCaseByPostcode");
 
-    CaseDTO response = new CaseDTO();
-    return ResponseEntity.ok(response);
+    List<CaseDTO> ccsCases = caseService.getCCSCaseByPostcode(postcode);
+    //    CaseDTO response = new CaseDTO();
+    return ResponseEntity.ok(ccsCases.get(0));
   }
+
+  // ---------------------------------------------------------------
+  // DUMMY ENDPOINTS FROM HERE
+  // ---------------------------------------------------------------
 
   private void validateMatchingCaseId(UUID caseId, UUID dtoCaseId) throws CTPException {
     if (!caseId.equals(dtoCaseId)) {

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpoint.java
@@ -317,16 +317,15 @@ public class CaseEndpoint implements CTPEndpoint {
    */
   @RequestMapping(value = "/ccs/postcode/{postcode}", method = RequestMethod.GET)
   @ResponseStatus(value = HttpStatus.OK)
-  public ResponseEntity<CaseDTO> getCCSCaseByPostcode(
+  public ResponseEntity<List<CaseDTO>> getCCSCaseByPostcode(
       @PathVariable(value = "postcode") @NotBlank @Pattern(regexp = Constants.POSTCODE_RE)
           final String postcode)
       throws CTPException {
 
     log.with("pathParam", postcode).info("Entering GET getCCSCaseByPostcode");
 
-    List<CaseDTO> ccsCases = caseService.getCCSCaseByPostcode(postcode);
-    //    CaseDTO response = new CaseDTO();
-    return ResponseEntity.ok(ccsCases.get(0));
+    List<CaseDTO> response = caseService.getCCSCaseByPostcode(postcode);
+    return ResponseEntity.ok(response);
   }
 
   // ---------------------------------------------------------------

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/CaseService.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/CaseService.java
@@ -58,4 +58,6 @@ public interface CaseService {
 
   ResponseDTO reportRefusal(UUID caseId, @Valid RefusalRequestDTO requestBodyDTO)
       throws CTPException;
+
+  List<CaseDTO> getCCSCaseByPostcode(final String postcode) throws CTPException;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -4,17 +4,12 @@ import static java.util.stream.Collectors.toList;
 
 import com.godaddy.logging.Logger;
 import com.godaddy.logging.LoggerFactory;
-import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -121,7 +116,7 @@ public class CaseServiceImpl implements CaseService {
   @Autowired private AddressService addressSvc;
 
   @Autowired private EventPublisher eventPublisher;
-  
+
   @Autowired private CCSPostcodesBean ccsPostcodesBean;
 
   private LuhnCheckDigit luhnChecker = new LuhnCheckDigit();

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -219,14 +219,6 @@ public class CaseServiceImpl implements CaseService {
     return createNewCachedCaseResponse(cachedCase, false);
   }
 
-  private void rejectHouseholdIndividual(CaseDTO caseDetails) {
-    if (caseDetails.getCaseType().equals(CaseType.HI.name())) {
-      log.with(caseDetails.getId())
-          .info("Case is not suitable as it is a household individual case");
-      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Case is not suitable");
-    }
-  }
-
   @Override
   public CaseDTO getCaseById(final UUID caseId, CaseQueryRequestDTO requestParamsDTO)
       throws CTPException {
@@ -240,90 +232,6 @@ public class CaseServiceImpl implements CaseService {
     log.with("caseId", caseId).debug("Returning case details for caseId");
 
     return caseServiceResponse;
-  }
-
-  private CaseDTO mapCaseContainerDTO(CaseContainerDTO caseDetails) {
-    CaseDTO caseServiceResponse = caseDTOMapper.map(caseDetails, CaseDTO.class);
-    caseServiceResponse.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
-    caseServiceResponse.setEstabType(EstabType.forCode(caseServiceResponse.getEstabDescription()));
-
-    return caseServiceResponse;
-  }
-
-  private List<CaseDTO> mapCaseContainerDTOList(List<CaseContainerDTO> casesToReturn) {
-    List<CaseDTO> caseServiceListResponse = caseDTOMapper.mapAsList(casesToReturn, CaseDTO.class);
-
-    for (CaseDTO caseServiceResponse : caseServiceListResponse) {
-      caseServiceResponse.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
-      caseServiceResponse.setEstabType(
-          EstabType.forCode(caseServiceResponse.getEstabDescription()));
-    }
-
-    return caseServiceListResponse;
-  }
-
-  private CaseDTO getLatestCaseById(UUID caseId, Boolean getCaseEvents) throws CTPException {
-    TimeOrderedCases timeOrderedCases = new TimeOrderedCases();
-
-    try {
-      CaseContainerDTO caseFromRM = getCaseFromRm(caseId, getCaseEvents);
-      if (caseFromRM != null) {
-        timeOrderedCases.addCase(mapCaseContainerDTO(caseFromRM));
-      }
-    } catch (ResponseStatusException ex) {
-      if (ex.getStatus() == HttpStatus.NOT_FOUND) {
-        log.with("caseId", caseId).debug("Case Id Not Found by Case Service");
-      } else {
-        log.with("caseId", caseId)
-            .with("status", ex.getStatus())
-            .error("Error calling Case Service");
-        throw ex;
-      }
-    }
-
-    Optional<CaseDTO> cachedCase =
-        dataRepo
-            .readCachedCaseById(caseId)
-            .map(cc -> createNewCachedCaseResponse(cc, getCaseEvents));
-
-    if (cachedCase.isPresent()) {
-      timeOrderedCases.addCase(cachedCase.get());
-    }
-    Optional<CaseDTO> latest = timeOrderedCases.latest();
-
-    CaseDTO latestCaseDto = null;
-    if (latest.isPresent()) {
-      latestCaseDto = latest.get();
-    } else {
-      log.with("caseId", caseId).warn("Request for case Not Found");
-      throw new CTPException(Fault.RESOURCE_NOT_FOUND, "Case Id Not Found: " + caseId.toString());
-    }
-
-    return latestCaseDto;
-  }
-
-  private Optional<CaseDTO> getLatestCaseByUprn(
-      UniquePropertyReferenceNumber uprn, boolean addCaseEvents) throws CTPException {
-    TimeOrderedCases timeOrderedCases = new TimeOrderedCases();
-
-    List<CaseDTO> rmCases = callCaseSvcByUPRN(uprn.getValue(), addCaseEvents);
-    log.with("uprn", uprn)
-        .with("cases", rmCases.size())
-        .debug("Found {} case details in RM for UPRN", rmCases.size());
-    timeOrderedCases.add(rmCases);
-
-    List<CaseDTO> cachedCases =
-        dataRepo
-            .readCachedCasesByUprn(uprn)
-            .stream()
-            .map(cc -> createNewCachedCaseResponse(cc, addCaseEvents))
-            .collect(toList());
-    log.with("uprn", uprn)
-        .with("cases", cachedCases.size())
-        .debug("Found {} case details in Cache for UPRN", cachedCases.size());
-    timeOrderedCases.add(cachedCases);
-
-    return timeOrderedCases.latest();
   }
 
   @Override
@@ -362,13 +270,6 @@ public class CaseServiceImpl implements CaseService {
     return ccsCases;
   }
 
-  private void validateCaseRef(long caseRef) throws CTPException {
-    if (!luhnChecker.isValid(Long.toString(caseRef))) {
-      log.with(caseRef).info("Luhn check failed for case Reference");
-      throw new CTPException(Fault.BAD_REQUEST, "Invalid Case Reference");
-    }
-  }
-
   @Override
   public CaseDTO getCaseByCaseReference(final long caseRef, CaseQueryRequestDTO requestParamsDTO)
       throws CTPException {
@@ -384,127 +285,6 @@ public class CaseServiceImpl implements CaseService {
     log.with("caseRef", caseRef).debug("Returning case details for case reference");
 
     return caseServiceResponse;
-  }
-
-  private void validateCompatibleEstabAndCaseType(CaseType caseType, EstabType estabType)
-      throws CTPException {
-    Optional<AddressType> addrType = estabType.getAddressType();
-    if (addrType.isPresent() && (caseType != CaseType.valueOf(addrType.get().name()))) {
-      log.with("caseType", caseType)
-          .with("estabType", estabType)
-          .info("Mismatching caseType and estabType");
-      String msg =
-          "Derived address type of '"
-              + addrType.get()
-              + "', from establishment type '"
-              + estabType
-              + "', "
-              + "is not compatible with caseType of '"
-              + caseType
-              + "'";
-      throw new CTPException(Fault.BAD_REQUEST, msg);
-    }
-  }
-
-  private boolean isCaseTypeChange(CaseType requestedCaseType, CaseType existingCaseType) {
-    return requestedCaseType != existingCaseType;
-  }
-
-  private void rejectNorthernIrelandHouseholdToCE(
-      CaseType requestedCaseType, CaseContainerDTO caseDetails) throws CTPException {
-    Region region = convertRegion(caseDetails);
-    if (region == Region.N && requestedCaseType == CaseType.CE) {
-      AddressType addrType = AddressType.valueOf(caseDetails.getCaseType());
-      if (addrType == AddressType.HH) {
-        String msg =
-            "All queries relating to Communal Establishments in Northern Ireland "
-                + "should be escalated to NISRA HQ";
-        log.with("caseType", requestedCaseType).with("caseDetails", caseDetails).info(msg);
-        throw new CTPException(Fault.BAD_REQUEST, msg);
-      }
-    }
-  }
-
-  private void updateOrCreateCachedCase(
-      UUID caseId, CaseContainerDTO caseDetails, ModifyCaseRequestDTO modifyRequestDTO)
-      throws CTPException {
-    CachedCase cachedCase = caseDTOMapper.map(caseDetails, CachedCase.class);
-    cachedCase.setId(caseId.toString());
-    CaseType caseType = modifyRequestDTO.getCaseType();
-    cachedCase.setCaseType(caseType);
-    cachedCase.setEstabType(modifyRequestDTO.getEstabType().getCode());
-    cachedCase.setAddressType(caseType.name());
-    cachedCase.setAddressLine1(modifyRequestDTO.getAddressLine1());
-    cachedCase.setAddressLine2(modifyRequestDTO.getAddressLine2());
-    cachedCase.setAddressLine3(modifyRequestDTO.getAddressLine3());
-    cachedCase.setCeOrgName(modifyRequestDTO.getCeOrgName());
-    dataRepo.writeCachedCase(cachedCase);
-  }
-
-  private void sendAddressModifiedEvent(
-      UUID caseId, ModifyCaseRequestDTO modifyRequestDTO, CaseContainerDTO caseDetails) {
-    CollectionCaseCompact collectionCase =
-        CollectionCaseCompact.builder()
-            .id(caseId)
-            .caseType(modifyRequestDTO.getCaseType().name())
-            .ceExpectedCapacity(modifyRequestDTO.getCeUsualResidents())
-            .build();
-    AddressCompact originalAddress = caseDTOMapper.map(caseDetails, AddressCompact.class);
-    AddressCompact newAddress = caseDTOMapper.map(caseDetails, AddressCompact.class);
-
-    newAddress.setAddressLine1(modifyRequestDTO.getAddressLine1());
-    newAddress.setAddressLine2(modifyRequestDTO.getAddressLine2());
-    newAddress.setAddressLine3(modifyRequestDTO.getAddressLine3());
-    newAddress.setEstabType(modifyRequestDTO.getEstabType().getCode());
-    newAddress.setOrganisationName(modifyRequestDTO.getCeOrgName());
-
-    AddressModification payload =
-        AddressModification.builder()
-            .collectionCase(collectionCase)
-            .originalAddress(originalAddress)
-            .newAddress(newAddress)
-            .build();
-    sendEvent(EventType.ADDRESS_MODIFIED, payload, caseId);
-  }
-
-  private void sendAddressTypeChangedEvent(
-      UUID newCaseId, UUID originalCaseId, ModifyCaseRequestDTO modifyRequestDTO) {
-    CollectionCase collectionCase = new CollectionCase();
-    collectionCase.setId(originalCaseId.toString());
-    collectionCase.setCeExpectedCapacity(modifyRequestDTO.getCeUsualResidents());
-    collectionCase.setContact(null);
-
-    Address address = new Address();
-    address.setAddressLine1(modifyRequestDTO.getAddressLine1());
-    address.setAddressLine2(modifyRequestDTO.getAddressLine2());
-    address.setAddressLine3(modifyRequestDTO.getAddressLine3());
-    address.setEstabType(modifyRequestDTO.getEstabType().getCode());
-    address.setOrganisationName(modifyRequestDTO.getCeOrgName());
-    address.setAddressType(modifyRequestDTO.getCaseType().name());
-
-    collectionCase.setAddress(address);
-
-    AddressTypeChanged payload =
-        AddressTypeChanged.builder().newCaseId(newCaseId).collectionCase(collectionCase).build();
-    sendEvent(EventType.ADDRESS_TYPE_CHANGED, payload, newCaseId);
-  }
-
-  private void prepareModificationResponse(
-      CaseDTO response, ModifyCaseRequestDTO modifyRequestDTO, UUID caseId, String caseRef) {
-    CaseType caseType = modifyRequestDTO.getCaseType();
-    response.setId(caseId);
-    response.setCaseRef(caseRef);
-    response.setCaseType(caseType.name());
-    response.setAddressType(caseType.name());
-    EstabType estabType = modifyRequestDTO.getEstabType();
-    response.setEstabType(estabType);
-    response.setEstabDescription(estabType.getCode());
-    response.setAddressLine1(modifyRequestDTO.getAddressLine1());
-    response.setAddressLine2(modifyRequestDTO.getAddressLine2());
-    response.setAddressLine3(modifyRequestDTO.getAddressLine3());
-    response.setCeOrgName(modifyRequestDTO.getCeOrgName());
-    response.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
-    response.setCaseEvents(Collections.emptyList());
   }
 
   @Override
@@ -538,12 +318,6 @@ public class CaseServiceImpl implements CaseService {
     updateOrCreateCachedCase(caseId, caseDetails, modifyRequestDTO);
     prepareModificationResponse(response, modifyRequestDTO, caseId, caseRef);
     return response;
-  }
-
-  private void validateSurveyType(CaseContainerDTO caseDetails) throws CTPException {
-    if (!appConfig.getSurveyName().equalsIgnoreCase(caseDetails.getSurveyType())) {
-      throw new CTPException(Fault.BAD_REQUEST, CCS_CASE_ERROR_MSG);
-    }
   }
 
   @Override
@@ -609,151 +383,6 @@ public class CaseServiceImpl implements CaseService {
         .uac(newQuestionnaireIdDto.getUac())
         .dateTime(DateTimeUtil.nowUTC())
         .build();
-  }
-
-  /**
-   * Request a new questionnaire Id for a Case
-   *
-   * @param caseDetails of case for which to get questionnaire Id
-   * @param individual whether request for individual questionnaire
-   * @return
-   */
-  private SingleUseQuestionnaireIdDTO getNewQidForCase(
-      CaseContainerDTO caseDetails, boolean individual) throws CTPException {
-
-    CaseType caseType = CaseType.valueOf(caseDetails.getCaseType());
-    if (!(caseType == CaseType.CE || caseType == CaseType.HH || caseType == CaseType.SPG)) {
-      throw new CTPException(Fault.BAD_REQUEST, "Case type must be SPG, CE or HH");
-    }
-
-    UUID parentCaseId = caseDetails.getId();
-    UUID individualCaseId = null;
-    if (caseType == CaseType.HH && individual) {
-      caseDetails = createIndividualCase(caseDetails);
-      individualCaseId = caseDetails.getId();
-    }
-
-    // Get RM to allocate a new questionnaire ID
-    log.info("Before new QID");
-    SingleUseQuestionnaireIdDTO newQuestionnaireIdDto;
-    try {
-      newQuestionnaireIdDto =
-          caseServiceClient.getSingleUseQuestionnaireId(parentCaseId, individual, individualCaseId);
-    } catch (ResponseStatusException ex) {
-      if (ex.getCause() != null) {
-        HttpStatusCodeException cause = (HttpStatusCodeException) ex.getCause();
-        log.with("caseid", parentCaseId)
-            .with("status", cause.getStatusCode())
-            .with("message", cause.getMessage())
-            .warn("New QID, UAC Case service request failure.");
-        if (cause.getStatusCode() == HttpStatus.BAD_REQUEST) {
-          throw new CTPException(
-              Fault.BAD_REQUEST, "Invalid request for case %s", parentCaseId.toString());
-        }
-      }
-      throw ex;
-    }
-
-    String questionnaireId = newQuestionnaireIdDto.getQuestionnaireId();
-    String formType = newQuestionnaireIdDto.getFormType();
-    log.with("newQuestionnaireID", questionnaireId)
-        .with("formType", formType)
-        .info("Have generated new questionnaireId");
-
-    if (caseType == CaseType.CE && !individual && FormType.C.name().equals(formType)) {
-      rejectInvalidLaunchCombinations(caseDetails.getRegion(), caseDetails.getAddressLevel());
-    }
-
-    return newQuestionnaireIdDto;
-  }
-
-  /**
-   * Get the Case for which the client has requested a launch URL/UAC
-   *
-   * @param caseId of case to get
-   * @return CaseContainerDTO for case requested
-   * @throws CTPException if case not available to call (not in case service), but new skeleton case
-   *     details available
-   */
-  private CaseContainerDTO getLaunchCase(UUID caseId) throws CTPException {
-    try {
-      CaseContainerDTO caseDetails = getCaseFromRm(caseId, false);
-      return caseDetails;
-    } catch (ResponseStatusException ex) {
-      if (ex.getStatus() == HttpStatus.NOT_FOUND) {
-        Optional<CachedCase> cachedCase = dataRepo.readCachedCaseById(caseId);
-        if (cachedCase.isPresent()) {
-          log.with("caseid", caseId)
-              .with("status", ex.getStatus())
-              .with("message", ex.getMessage())
-              .warn("New skeleton case created but not yet available.");
-          throw new CTPException(
-              Fault.ACCEPTED_UNABLE_TO_PROCESS,
-              "Unable to provide launch URL/UAC at present, please try again later.");
-        }
-      }
-      log.with("caseid", caseId)
-          .with("status", ex.getStatus())
-          .with("message", ex.getMessage())
-          .error("Unable to provide launch URL/UAC, failed to call case service");
-      throw ex;
-    }
-  }
-
-  private void rejectInvalidLaunchCombinations(String region, String addressLevel)
-      throws CTPException {
-    if ("E".equals(addressLevel)) {
-      if ("N".equals(region)) {
-        throw new CTPException(Fault.BAD_REQUEST, NI_LAUNCH_ERR_MSG);
-      }
-    } else if ("U".equals(addressLevel)) {
-      if (VALID_REGIONS.contains(region)) {
-        throw new CTPException(Fault.BAD_REQUEST, UNIT_LAUNCH_ERR_MSG);
-      }
-    }
-  }
-
-  // Create a new case for a HH individual
-  private CaseContainerDTO createIndividualCase(CaseContainerDTO caseDetails) {
-    UUID individualCaseId = UUID.randomUUID();
-    caseDetails.setId(individualCaseId);
-    caseDetails.setCaseType(CaseType.HI.name());
-    log.with("individualCaseId", individualCaseId).info("Creating new HI case");
-    return caseDetails;
-  }
-
-  private String createLaunchUrl(
-      String formType,
-      CaseContainerDTO caseDetails,
-      LaunchRequestDTO requestParamsDTO,
-      String questionnaireId)
-      throws CTPException {
-    String encryptedPayload = "";
-    try {
-      encryptedPayload =
-          eqLaunchService.getEqLaunchJwe(
-              Language.ENGLISH,
-              uk.gov.ons.ctp.common.domain.Source.CONTACT_CENTRE_API,
-              uk.gov.ons.ctp.common.domain.Channel.CC,
-              caseDetails,
-              Integer.toString(requestParamsDTO.getAgentId()),
-              questionnaireId,
-              formType,
-              null,
-              null,
-              appConfig.getKeystore());
-    } catch (CTPException e) {
-      log.with(e).error("Failed to create JWE payload for eq launch");
-      throw e;
-    }
-    String eqUrl =
-        appConfig.getEq().getProtocol()
-            + "://"
-            + appConfig.getEq().getHost()
-            + appConfig.getEq().getPath()
-            + encryptedPayload;
-    log.with("launchURL", eqUrl).debug("Have created launch URL");
-    return eqUrl;
   }
 
   @Override
@@ -1204,5 +833,376 @@ public class CaseServiceImpl implements CaseService {
       throw new CTPException(
           Fault.BAD_REQUEST, "The requested postcode is not within the CCS sample");
     }
+  }
+
+  private void rejectHouseholdIndividual(CaseDTO caseDetails) {
+    if (caseDetails.getCaseType().equals(CaseType.HI.name())) {
+      log.with(caseDetails.getId())
+          .info("Case is not suitable as it is a household individual case");
+      throw new ResponseStatusException(HttpStatus.FORBIDDEN, "Case is not suitable");
+    }
+  }
+
+  private CaseDTO mapCaseContainerDTO(CaseContainerDTO caseDetails) {
+    CaseDTO caseServiceResponse = caseDTOMapper.map(caseDetails, CaseDTO.class);
+    caseServiceResponse.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
+    caseServiceResponse.setEstabType(EstabType.forCode(caseServiceResponse.getEstabDescription()));
+
+    return caseServiceResponse;
+  }
+
+  private List<CaseDTO> mapCaseContainerDTOList(List<CaseContainerDTO> casesToReturn) {
+    List<CaseDTO> caseServiceListResponse = caseDTOMapper.mapAsList(casesToReturn, CaseDTO.class);
+
+    for (CaseDTO caseServiceResponse : caseServiceListResponse) {
+      caseServiceResponse.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
+      caseServiceResponse.setEstabType(
+          EstabType.forCode(caseServiceResponse.getEstabDescription()));
+    }
+
+    return caseServiceListResponse;
+  }
+
+  private CaseDTO getLatestCaseById(UUID caseId, Boolean getCaseEvents) throws CTPException {
+    TimeOrderedCases timeOrderedCases = new TimeOrderedCases();
+
+    try {
+      CaseContainerDTO caseFromRM = getCaseFromRm(caseId, getCaseEvents);
+      if (caseFromRM != null) {
+        timeOrderedCases.addCase(mapCaseContainerDTO(caseFromRM));
+      }
+    } catch (ResponseStatusException ex) {
+      if (ex.getStatus() == HttpStatus.NOT_FOUND) {
+        log.with("caseId", caseId).debug("Case Id Not Found by Case Service");
+      } else {
+        log.with("caseId", caseId)
+            .with("status", ex.getStatus())
+            .error("Error calling Case Service");
+        throw ex;
+      }
+    }
+
+    Optional<CaseDTO> cachedCase =
+        dataRepo
+            .readCachedCaseById(caseId)
+            .map(cc -> createNewCachedCaseResponse(cc, getCaseEvents));
+
+    if (cachedCase.isPresent()) {
+      timeOrderedCases.addCase(cachedCase.get());
+    }
+    Optional<CaseDTO> latest = timeOrderedCases.latest();
+
+    CaseDTO latestCaseDto = null;
+    if (latest.isPresent()) {
+      latestCaseDto = latest.get();
+    } else {
+      log.with("caseId", caseId).warn("Request for case Not Found");
+      throw new CTPException(Fault.RESOURCE_NOT_FOUND, "Case Id Not Found: " + caseId.toString());
+    }
+
+    return latestCaseDto;
+  }
+
+  private Optional<CaseDTO> getLatestCaseByUprn(
+      UniquePropertyReferenceNumber uprn, boolean addCaseEvents) throws CTPException {
+    TimeOrderedCases timeOrderedCases = new TimeOrderedCases();
+
+    List<CaseDTO> rmCases = callCaseSvcByUPRN(uprn.getValue(), addCaseEvents);
+    log.with("uprn", uprn)
+        .with("cases", rmCases.size())
+        .debug("Found {} case details in RM for UPRN", rmCases.size());
+    timeOrderedCases.add(rmCases);
+
+    List<CaseDTO> cachedCases =
+        dataRepo
+            .readCachedCasesByUprn(uprn)
+            .stream()
+            .map(cc -> createNewCachedCaseResponse(cc, addCaseEvents))
+            .collect(toList());
+    log.with("uprn", uprn)
+        .with("cases", cachedCases.size())
+        .debug("Found {} case details in Cache for UPRN", cachedCases.size());
+    timeOrderedCases.add(cachedCases);
+
+    return timeOrderedCases.latest();
+  }
+
+  private void validateCaseRef(long caseRef) throws CTPException {
+    if (!luhnChecker.isValid(Long.toString(caseRef))) {
+      log.with(caseRef).info("Luhn check failed for case Reference");
+      throw new CTPException(Fault.BAD_REQUEST, "Invalid Case Reference");
+    }
+  }
+
+  private void validateCompatibleEstabAndCaseType(CaseType caseType, EstabType estabType)
+      throws CTPException {
+    Optional<AddressType> addrType = estabType.getAddressType();
+    if (addrType.isPresent() && (caseType != CaseType.valueOf(addrType.get().name()))) {
+      log.with("caseType", caseType)
+          .with("estabType", estabType)
+          .info("Mismatching caseType and estabType");
+      String msg =
+          "Derived address type of '"
+              + addrType.get()
+              + "', from establishment type '"
+              + estabType
+              + "', "
+              + "is not compatible with caseType of '"
+              + caseType
+              + "'";
+      throw new CTPException(Fault.BAD_REQUEST, msg);
+    }
+  }
+
+  private boolean isCaseTypeChange(CaseType requestedCaseType, CaseType existingCaseType) {
+    return requestedCaseType != existingCaseType;
+  }
+
+  private void rejectNorthernIrelandHouseholdToCE(
+      CaseType requestedCaseType, CaseContainerDTO caseDetails) throws CTPException {
+    Region region = convertRegion(caseDetails);
+    if (region == Region.N && requestedCaseType == CaseType.CE) {
+      AddressType addrType = AddressType.valueOf(caseDetails.getCaseType());
+      if (addrType == AddressType.HH) {
+        String msg =
+            "All queries relating to Communal Establishments in Northern Ireland "
+                + "should be escalated to NISRA HQ";
+        log.with("caseType", requestedCaseType).with("caseDetails", caseDetails).info(msg);
+        throw new CTPException(Fault.BAD_REQUEST, msg);
+      }
+    }
+  }
+
+  private void updateOrCreateCachedCase(
+      UUID caseId, CaseContainerDTO caseDetails, ModifyCaseRequestDTO modifyRequestDTO)
+      throws CTPException {
+    CachedCase cachedCase = caseDTOMapper.map(caseDetails, CachedCase.class);
+    cachedCase.setId(caseId.toString());
+    CaseType caseType = modifyRequestDTO.getCaseType();
+    cachedCase.setCaseType(caseType);
+    cachedCase.setEstabType(modifyRequestDTO.getEstabType().getCode());
+    cachedCase.setAddressType(caseType.name());
+    cachedCase.setAddressLine1(modifyRequestDTO.getAddressLine1());
+    cachedCase.setAddressLine2(modifyRequestDTO.getAddressLine2());
+    cachedCase.setAddressLine3(modifyRequestDTO.getAddressLine3());
+    cachedCase.setCeOrgName(modifyRequestDTO.getCeOrgName());
+    dataRepo.writeCachedCase(cachedCase);
+  }
+
+  private void sendAddressModifiedEvent(
+      UUID caseId, ModifyCaseRequestDTO modifyRequestDTO, CaseContainerDTO caseDetails) {
+    CollectionCaseCompact collectionCase =
+        CollectionCaseCompact.builder()
+            .id(caseId)
+            .caseType(modifyRequestDTO.getCaseType().name())
+            .ceExpectedCapacity(modifyRequestDTO.getCeUsualResidents())
+            .build();
+    AddressCompact originalAddress = caseDTOMapper.map(caseDetails, AddressCompact.class);
+    AddressCompact newAddress = caseDTOMapper.map(caseDetails, AddressCompact.class);
+
+    newAddress.setAddressLine1(modifyRequestDTO.getAddressLine1());
+    newAddress.setAddressLine2(modifyRequestDTO.getAddressLine2());
+    newAddress.setAddressLine3(modifyRequestDTO.getAddressLine3());
+    newAddress.setEstabType(modifyRequestDTO.getEstabType().getCode());
+    newAddress.setOrganisationName(modifyRequestDTO.getCeOrgName());
+
+    AddressModification payload =
+        AddressModification.builder()
+            .collectionCase(collectionCase)
+            .originalAddress(originalAddress)
+            .newAddress(newAddress)
+            .build();
+    sendEvent(EventType.ADDRESS_MODIFIED, payload, caseId);
+  }
+
+  private void sendAddressTypeChangedEvent(
+      UUID newCaseId, UUID originalCaseId, ModifyCaseRequestDTO modifyRequestDTO) {
+    CollectionCase collectionCase = new CollectionCase();
+    collectionCase.setId(originalCaseId.toString());
+    collectionCase.setCeExpectedCapacity(modifyRequestDTO.getCeUsualResidents());
+    collectionCase.setContact(null);
+
+    Address address = new Address();
+    address.setAddressLine1(modifyRequestDTO.getAddressLine1());
+    address.setAddressLine2(modifyRequestDTO.getAddressLine2());
+    address.setAddressLine3(modifyRequestDTO.getAddressLine3());
+    address.setEstabType(modifyRequestDTO.getEstabType().getCode());
+    address.setOrganisationName(modifyRequestDTO.getCeOrgName());
+    address.setAddressType(modifyRequestDTO.getCaseType().name());
+
+    collectionCase.setAddress(address);
+
+    AddressTypeChanged payload =
+        AddressTypeChanged.builder().newCaseId(newCaseId).collectionCase(collectionCase).build();
+    sendEvent(EventType.ADDRESS_TYPE_CHANGED, payload, newCaseId);
+  }
+
+  private void prepareModificationResponse(
+      CaseDTO response, ModifyCaseRequestDTO modifyRequestDTO, UUID caseId, String caseRef) {
+    CaseType caseType = modifyRequestDTO.getCaseType();
+    response.setId(caseId);
+    response.setCaseRef(caseRef);
+    response.setCaseType(caseType.name());
+    response.setAddressType(caseType.name());
+    EstabType estabType = modifyRequestDTO.getEstabType();
+    response.setEstabType(estabType);
+    response.setEstabDescription(estabType.getCode());
+    response.setAddressLine1(modifyRequestDTO.getAddressLine1());
+    response.setAddressLine2(modifyRequestDTO.getAddressLine2());
+    response.setAddressLine3(modifyRequestDTO.getAddressLine3());
+    response.setCeOrgName(modifyRequestDTO.getCeOrgName());
+    response.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
+    response.setCaseEvents(Collections.emptyList());
+  }
+
+  private void validateSurveyType(CaseContainerDTO caseDetails) throws CTPException {
+    if (!appConfig.getSurveyName().equalsIgnoreCase(caseDetails.getSurveyType())) {
+      throw new CTPException(Fault.BAD_REQUEST, CCS_CASE_ERROR_MSG);
+    }
+  }
+
+  /**
+   * Request a new questionnaire Id for a Case
+   *
+   * @param caseDetails of case for which to get questionnaire Id
+   * @param individual whether request for individual questionnaire
+   * @return
+   */
+  private SingleUseQuestionnaireIdDTO getNewQidForCase(
+      CaseContainerDTO caseDetails, boolean individual) throws CTPException {
+
+    CaseType caseType = CaseType.valueOf(caseDetails.getCaseType());
+    if (!(caseType == CaseType.CE || caseType == CaseType.HH || caseType == CaseType.SPG)) {
+      throw new CTPException(Fault.BAD_REQUEST, "Case type must be SPG, CE or HH");
+    }
+
+    UUID parentCaseId = caseDetails.getId();
+    UUID individualCaseId = null;
+    if (caseType == CaseType.HH && individual) {
+      caseDetails = createIndividualCase(caseDetails);
+      individualCaseId = caseDetails.getId();
+    }
+
+    // Get RM to allocate a new questionnaire ID
+    log.info("Before new QID");
+    SingleUseQuestionnaireIdDTO newQuestionnaireIdDto;
+    try {
+      newQuestionnaireIdDto =
+          caseServiceClient.getSingleUseQuestionnaireId(parentCaseId, individual, individualCaseId);
+    } catch (ResponseStatusException ex) {
+      if (ex.getCause() != null) {
+        HttpStatusCodeException cause = (HttpStatusCodeException) ex.getCause();
+        log.with("caseid", parentCaseId)
+            .with("status", cause.getStatusCode())
+            .with("message", cause.getMessage())
+            .warn("New QID, UAC Case service request failure.");
+        if (cause.getStatusCode() == HttpStatus.BAD_REQUEST) {
+          throw new CTPException(
+              Fault.BAD_REQUEST, "Invalid request for case %s", parentCaseId.toString());
+        }
+      }
+      throw ex;
+    }
+
+    String questionnaireId = newQuestionnaireIdDto.getQuestionnaireId();
+    String formType = newQuestionnaireIdDto.getFormType();
+    log.with("newQuestionnaireID", questionnaireId)
+        .with("formType", formType)
+        .info("Have generated new questionnaireId");
+
+    if (caseType == CaseType.CE && !individual && FormType.C.name().equals(formType)) {
+      rejectInvalidLaunchCombinations(caseDetails.getRegion(), caseDetails.getAddressLevel());
+    }
+
+    return newQuestionnaireIdDto;
+  }
+
+  /**
+   * Get the Case for which the client has requested a launch URL/UAC
+   *
+   * @param caseId of case to get
+   * @return CaseContainerDTO for case requested
+   * @throws CTPException if case not available to call (not in case service), but new skeleton case
+   *     details available
+   */
+  private CaseContainerDTO getLaunchCase(UUID caseId) throws CTPException {
+    try {
+      CaseContainerDTO caseDetails = getCaseFromRm(caseId, false);
+      return caseDetails;
+    } catch (ResponseStatusException ex) {
+      if (ex.getStatus() == HttpStatus.NOT_FOUND) {
+        Optional<CachedCase> cachedCase = dataRepo.readCachedCaseById(caseId);
+        if (cachedCase.isPresent()) {
+          log.with("caseid", caseId)
+              .with("status", ex.getStatus())
+              .with("message", ex.getMessage())
+              .warn("New skeleton case created but not yet available.");
+          throw new CTPException(
+              Fault.ACCEPTED_UNABLE_TO_PROCESS,
+              "Unable to provide launch URL/UAC at present, please try again later.");
+        }
+      }
+      log.with("caseid", caseId)
+          .with("status", ex.getStatus())
+          .with("message", ex.getMessage())
+          .error("Unable to provide launch URL/UAC, failed to call case service");
+      throw ex;
+    }
+  }
+
+  private void rejectInvalidLaunchCombinations(String region, String addressLevel)
+      throws CTPException {
+    if ("E".equals(addressLevel)) {
+      if ("N".equals(region)) {
+        throw new CTPException(Fault.BAD_REQUEST, NI_LAUNCH_ERR_MSG);
+      }
+    } else if ("U".equals(addressLevel)) {
+      if (VALID_REGIONS.contains(region)) {
+        throw new CTPException(Fault.BAD_REQUEST, UNIT_LAUNCH_ERR_MSG);
+      }
+    }
+  }
+
+  // Create a new case for a HH individual
+  private CaseContainerDTO createIndividualCase(CaseContainerDTO caseDetails) {
+    UUID individualCaseId = UUID.randomUUID();
+    caseDetails.setId(individualCaseId);
+    caseDetails.setCaseType(CaseType.HI.name());
+    log.with("individualCaseId", individualCaseId).info("Creating new HI case");
+    return caseDetails;
+  }
+
+  private String createLaunchUrl(
+      String formType,
+      CaseContainerDTO caseDetails,
+      LaunchRequestDTO requestParamsDTO,
+      String questionnaireId)
+      throws CTPException {
+    String encryptedPayload = "";
+    try {
+      encryptedPayload =
+          eqLaunchService.getEqLaunchJwe(
+              Language.ENGLISH,
+              uk.gov.ons.ctp.common.domain.Source.CONTACT_CENTRE_API,
+              uk.gov.ons.ctp.common.domain.Channel.CC,
+              caseDetails,
+              Integer.toString(requestParamsDTO.getAgentId()),
+              questionnaireId,
+              formType,
+              null,
+              null,
+              appConfig.getKeystore());
+    } catch (CTPException e) {
+      log.with(e).error("Failed to create JWE payload for eq launch");
+      throw e;
+    }
+    String eqUrl =
+        appConfig.getEq().getProtocol()
+            + "://"
+            + appConfig.getEq().getHost()
+            + appConfig.getEq().getPath()
+            + encryptedPayload;
+    log.with("launchURL", eqUrl).debug("Have created launch URL");
+    return eqUrl;
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -346,6 +346,7 @@ public class CaseServiceImpl implements CaseService {
   @Override
   public List<CaseDTO> getCCSCaseByPostcode(String postcode) throws CTPException {
     log.with("postcode", postcode).debug("Fetching ccs case details by postcode");
+    validatePostcode(postcode);
 
     List<CaseContainerDTO> ccsCaseContainersList = getCcsCasesFromRm(postcode);
 
@@ -1186,5 +1187,13 @@ public class CaseServiceImpl implements CaseService {
     log.with("caseId", caseId)
         .with("transactionId", transactionId)
         .debug("{} event published", eventType);
+  }
+
+  private void validatePostcode(String postcode) throws CTPException {
+    if (!postcode.equals("G12AA")) {
+      log.with(postcode).info("Check failed for postcode");
+      throw new CTPException(
+          Fault.BAD_REQUEST, "The requested postcode is not within the CCS sample");
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -88,8 +88,6 @@ import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 import uk.gov.ons.ctp.integration.contactcentresvc.util.PgpEncrypt;
 import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchService;
 
-// import java.util.List;
-
 @Service
 public class CaseServiceImpl implements CaseService {
 
@@ -1186,7 +1184,6 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private void sendEvent(EventType eventType, EventPayload payload, Object caseId) {
-
     String transactionId =
         eventPublisher.sendEvent(
             eventType, Source.CONTACT_CENTRE_API, appConfig.getChannel(), payload);
@@ -1209,10 +1206,9 @@ public class CaseServiceImpl implements CaseService {
   private Set<String> getPostcodes() {
     Set<String> ccsPostcodes = new HashSet<>();
     String strPostcodePath = appConfig.getCcsPostcodes().getCcsPostcodePath();
-    List<String> postcodes;
-    Path postcodeFilePath;
-    postcodeFilePath = Paths.get(strPostcodePath);
 
+    Path postcodeFilePath = Paths.get(strPostcodePath);
+    List<String> postcodes;
     try {
       postcodes = Files.readAllLines(postcodeFilePath);
       for (String postcode : postcodes) {
@@ -1225,7 +1221,7 @@ public class CaseServiceImpl implements CaseService {
               "IOException caught as unable to read in postcodes from file."
                   + " Using postcodes from application.yml instead.",
               e);
-      ccsPostcodes = appConfig.getCcsPostcodes().getCcsPostcodesToCheck();
+      ccsPostcodes = appConfig.getCcsPostcodes().getCcsDefaultPostcodes();
     }
     return ccsPostcodes;
   }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1190,7 +1190,7 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private void validatePostcode(String postcode) throws CTPException {
-    if (!postcode.equals("G12AA")) {
+    if (!appConfig.getCcsPostcodes().isInCCSPostcodes(postcode)) {
       log.with(postcode).info("Check failed for postcode");
       throw new CTPException(
           Fault.BAD_REQUEST, "The requested postcode is not within the CCS sample");

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -343,6 +343,20 @@ public class CaseServiceImpl implements CaseService {
     return Collections.singletonList(response);
   }
 
+  @Override
+  public List<CaseDTO> getCCSCaseByPostcode(String postcode) throws CTPException {
+    log.with("postcode", postcode).debug("Fetching ccs case details by postcode");
+
+    List<CaseContainerDTO> ccsCaseContainersList = getCcsCasesFromRm(postcode);
+
+    List<CaseDTO> ccsCases = new ArrayList<CaseDTO>();
+    for (CaseContainerDTO ccsCaseDetails : ccsCaseContainersList) {
+      ccsCases.add(caseDTOMapper.map(ccsCaseDetails, CaseDTO.class));
+    }
+
+    return ccsCases;
+  }
+
   private void validateCaseRef(long caseRef) throws CTPException {
     if (!luhnChecker.isValid(Long.toString(caseRef))) {
       log.with(caseRef).info("Luhn check failed for case Reference");
@@ -972,6 +986,11 @@ public class CaseServiceImpl implements CaseService {
   private List<CaseContainerDTO> getCasesFromRm(long uprn, boolean getCaseEvents) {
     var caseList = caseServiceClient.getCaseByUprn(uprn, getCaseEvents);
     return caseList.stream().map(c -> filterCaseEvents(c, getCaseEvents)).collect(toList());
+  }
+
+  private List<CaseContainerDTO> getCcsCasesFromRm(String postcode) {
+    List<CaseContainerDTO> caseList = caseServiceClient.getCcsCaseByPostcode(postcode);
+    return caseList;
   }
 
   /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -162,7 +162,7 @@ cloud-storage:
     
 ccs-postcodes:
   ccs-postcode-path: /etc/config/ccs-postcodes
-  ccs-postcodes-to-check:
+  ccs-default-postcodes:
       - HP22 4HU
       - HP22 4JS
       - HP22 4LG

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -170,3 +170,4 @@ ccs-postcodes:
       - HP224PS
       - GW12AAA
       - GW12AAB
+  ccs-postcode-path: /etc/config/ccs-postcodes

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -162,12 +162,12 @@ cloud-storage:
     
 ccs-postcodes:
   ccs-postcodes-to-check:
-      - HP224HU
-      - HP224JS
-      - HP224LG
-      - HP224NH
-      - HP224PL
-      - HP224PS
-      - GW12AAA
-      - GW12AAB
+      - HP22 4HU
+      - HP22 4JS
+      - HP22 4LG
+      - HP22 4NH
+      - HP22 4PL
+      - HP22 4PS
+      - GW12 AAA
+      - GW12 AAB
   ccs-postcode-path: /etc/config/ccs-postcodes

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -161,6 +161,7 @@ cloud-storage:
     max-attempts: 3
     
 ccs-postcodes:
+  ccs-postcode-path: /etc/config/ccs-postcodes
   ccs-postcodes-to-check:
       - HP22 4HU
       - HP22 4JS
@@ -170,4 +171,4 @@ ccs-postcodes:
       - HP22 4PS
       - GW12 AAA
       - GW12 AAB
-  ccs-postcode-path: /etc/config/ccs-postcodes
+  

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -159,3 +159,14 @@ cloud-storage:
     multiplier: 2
     max: 3500
     max-attempts: 3
+    
+ccs-postcodes:
+  ccs-postcodes-to-check:
+      - HP224HU
+      - HP224JS
+      - HP224LG
+      - HP224NH
+      - HP224PL
+      - HP224PS
+      - GW12AAA
+      - GW12AAB

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -161,6 +161,8 @@ cloud-storage:
     max-attempts: 3
     
 ccs-postcodes:
+# The ccs-postcode-path will be provided within GCP k8s as an environment variable, the contents of that file will be a volume mounted configmap property. 
+# See census-int-terraform/kubernetes/contact-centre-service/contact-centre-service-deployment.yml
   ccs-postcode-path: /etc/config/ccs-postcodes
   ccs-default-postcodes:
       - HP22 4HU

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointGetCcsCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointGetCcsCaseTest.java
@@ -1,0 +1,272 @@
+package uk.gov.ons.ctp.integration.contactcentresvc.endpoint;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.ons.ctp.common.MvcHelper.getJson;
+import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAdviceFor;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
+import uk.gov.ons.ctp.common.error.RestExceptionHandler;
+import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
+
+/**
+ * Contact Centre Data Endpoint Unit tests. This class tests the get case endpoints, covering gets
+ * based on uuid, ref and uprn.
+ */
+public final class CaseEndpointGetCcsCaseTest {
+
+  private static final String CASE_UUID_STRING = "dca05c61-8b95-46af-8f73-36f0dc2cbf5e";
+  private static final String CASE_REF = "123456";
+  private static final String CASE_TYPE = "R1";
+  private static final String CASE_CREATED_DATE_TIME = "2019-01-29T14:14:27.512Z";
+  private static final String ADDRESS_LINE_1 = "Smiths Renovations";
+  private static final String ADDRESS_LINE_2 = "Rock House";
+  private static final String ADDRESS_LINE_3 = "Cowick Lane";
+  private static final String TOWN = "Exeter";
+  private static final String REGION = "E";
+  private static final String POSTCODE = "GW12 AAA";
+  private static final String ORG_NAME = "Tiddlywink Athletic Club";
+
+  private static final String EVENT_CATEGORY = "REFUSAL";
+  private static final String EVENT_DESCRIPTION = "Event for testcase";
+  private static final String EVENT_DATE_TIME = "2017-02-11T16:32:11.863Z";
+
+  @InjectMocks private CaseEndpoint caseEndpoint;
+
+  @Mock CaseService caseService;
+
+  private MockMvc mockMvc;
+
+  private UUID uuid = UUID.randomUUID();
+
+  /**
+   * Set up of tests
+   *
+   * @throws Exception exception thrown
+   */
+  @Before
+  public void setUp() throws Exception {
+    MockitoAnnotations.initMocks(this);
+
+    this.mockMvc =
+        MockMvcBuilders.standaloneSetup(caseEndpoint)
+            .setHandlerExceptionResolvers(mockAdviceFor(RestExceptionHandler.class))
+            .setMessageConverters(new MappingJackson2HttpMessageConverter(new CustomObjectMapper()))
+            .build();
+  }
+
+//@Test
+//  public void getCaseById_GoodId() throws Exception {
+//    CaseDTO testCaseDTO = createResponseCaseDTO();
+//    Mockito.when(caseService.getCaseById(eq(uuid), any())).thenReturn(testCaseDTO);
+//
+//    ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid));
+//    actions.andExpect(status().isOk());
+//
+//    verifyStructureOfResultsActions(actions);
+//  }
+  
+  @Test
+  public void getCcsCaseByPostcode_PostcodeInList() throws Exception {
+    List<CaseDTO> testCases = new ArrayList<>();
+    testCases.add(createResponseCaseDTO());
+    testCases.add(createResponseCaseDTO());
+    Mockito.when(caseService.getCCSCaseByPostcode(eq(POSTCODE))).thenReturn(testCases);
+
+    ResultActions actions = mockMvc.perform(getJson("/cases/ccs/postcode/" + POSTCODE));
+    actions.andExpect(status().isOk());
+    
+    verifyStructureOfMultiResultsActions(actions);
+  }
+
+//  @Test
+//  public void getCaseById_BadId() throws Exception {
+//    ResultActions actions = mockMvc.perform(getJson("/cases/123456789"));
+//    actions.andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  public void getCaseById_CaseEventsTrue() throws Exception {
+//    CaseDTO testCaseDTO = createResponseCaseDTO();
+//    Mockito.when(caseService.getCaseById(eq(uuid), any())).thenReturn(testCaseDTO);
+//
+//    ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid + "?caseEvents=1"));
+//    actions.andExpect(status().isOk());
+//
+//    verifyStructureOfResultsActions(actions);
+//  }
+//
+//  @Test
+//  public void getCaseById_CaseEventsDuff() throws Exception {
+//    ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid + "?caseEvents=maybe"));
+//    actions.andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  public void getCaseByRef_GoodRef() throws Exception {
+//    CaseDTO testCaseDTO = createResponseCaseDTO();
+//    Mockito.when(caseService.getCaseByCaseReference(eq(123456L), any())).thenReturn(testCaseDTO);
+//
+//    ResultActions actions = mockMvc.perform(getJson("/cases/ref/123456"));
+//    actions.andExpect(status().isOk());
+//
+//    verifyStructureOfResultsActions(actions);
+//  }
+//
+//  @Test
+//  public void getCaseByRef_BadRef() throws Exception {
+//    ResultActions actions = mockMvc.perform(getJson("/cases/ref/avg"));
+//    actions.andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  public void getCaseByUprn_GoodUPRN() throws Exception {
+//    List<CaseDTO> testCases = new ArrayList<>();
+//    testCases.add(createResponseCaseDTO());
+//    testCases.add(createResponseCaseDTO());
+//    UniquePropertyReferenceNumber expectedUprn = new UniquePropertyReferenceNumber(123456789012L);
+//    Mockito.when(caseService.getCaseByUPRN(eq(expectedUprn), any())).thenReturn(testCases);
+//
+//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012"));
+//    actions.andExpect(status().isOk());
+//
+//    verifyStructureOfMultiResultsActions(actions);
+//  }
+//
+//  @Test
+//  public void getCaseByUprn_UPRNTooLong() throws Exception {
+//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012345"));
+//    actions.andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  public void getCaseByUprn_BadUPRN() throws Exception {
+//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/A12345678901234"));
+//    actions.andExpect(status().isBadRequest());
+//  }
+//
+//  @Test
+//  public void getCaseByUprn_CaseEventsTrue() throws Exception {
+//    List<CaseDTO> testCases = new ArrayList<>();
+//    testCases.add(createResponseCaseDTO());
+//    testCases.add(createResponseCaseDTO());
+//    UniquePropertyReferenceNumber expectedUprn = new UniquePropertyReferenceNumber(123456789012L);
+//    Mockito.when(caseService.getCaseByUPRN(eq(expectedUprn), any())).thenReturn(testCases);
+//
+//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012?caseEvents=1"));
+//    actions.andExpect(status().isOk());
+//
+//    verifyStructureOfMultiResultsActions(actions);
+//  }
+//
+//  @Test
+//  public void getCaseByUprn_CaseEventsDuff() throws Exception {
+//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/12345678901234?caseEvents=maybe"));
+//    actions.andExpect(status().isBadRequest());
+//  }
+//
+  private CaseDTO createResponseCaseDTO() throws ParseException {
+    SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
+
+    CaseEventDTO caseEventDTO1 =
+        CaseEventDTO.builder()
+            .description(EVENT_DESCRIPTION)
+            .category(EVENT_CATEGORY)
+            .createdDateTime(formatter.parse(EVENT_DATE_TIME))
+            .build();
+
+    CaseDTO fakeCaseDTO =
+        CaseDTO.builder()
+            .id(UUID.fromString(CASE_UUID_STRING))
+            .caseRef(CASE_REF)
+            .caseType(CASE_TYPE)
+            .createdDateTime(formatter.parse(CASE_CREATED_DATE_TIME))
+            .addressLine1(ADDRESS_LINE_1)
+            .addressLine2(ADDRESS_LINE_2)
+            .addressLine3(ADDRESS_LINE_3)
+            .townName(TOWN)
+            .region(REGION)
+            .postcode(POSTCODE)
+            .ceOrgName(ORG_NAME)
+            .caseEvents(Arrays.asList(caseEventDTO1))
+            .build();
+
+    return fakeCaseDTO;
+  }
+
+//  private void verifyStructureOfResultsActions(ResultActions actions) throws Exception {
+//    actions.andExpect(jsonPath("$[0].id", is(CASE_UUID_STRING)));
+//    actions.andExpect(jsonPath("$[0].caseRef", is(CASE_REF)));
+//    actions.andExpect(jsonPath("$[0].caseType", is(CASE_TYPE)));
+//    actions.andExpect(jsonPath("$[0].createdDateTime", is(CASE_CREATED_DATE_TIME)));
+//    actions.andExpect(jsonPath("$[0].addressLine1", is(ADDRESS_LINE_1)));
+//    actions.andExpect(jsonPath("$[0].addressLine2", is(ADDRESS_LINE_2)));
+//    actions.andExpect(jsonPath("$[0].addressLine3", is(ADDRESS_LINE_3)));
+//    actions.andExpect(jsonPath("$[0].townName", is(TOWN)));
+//    actions.andExpect(jsonPath("$[0].region", is(REGION)));
+//    actions.andExpect(jsonPath("$[0].postcode", is(POSTCODE)));
+//    actions.andExpect(jsonPath("$[0].ceOrgName", is(ORG_NAME)));
+//
+//    actions.andExpect(jsonPath("$[0].caseEvents[0].category", is(EVENT_CATEGORY)));
+//    actions.andExpect(jsonPath("$[0].caseEvents[0].description", is(EVENT_DESCRIPTION)));
+//    actions.andExpect(jsonPath("$[0].caseEvents[0].createdDateTime", is(EVENT_DATE_TIME)));
+//  }
+
+  private void verifyStructureOfMultiResultsActions(ResultActions actions) throws Exception {
+    // This is not ideal - obvious duplication here - want to find a neater way of making the same
+    // assertions repeatedly
+    actions.andExpect(jsonPath("$[0].id", is(CASE_UUID_STRING)));
+    actions.andExpect(jsonPath("$[0].caseRef", is(CASE_REF)));
+    actions.andExpect(jsonPath("$[0].caseType", is(CASE_TYPE)));
+    actions.andExpect(jsonPath("$[0].createdDateTime", is(CASE_CREATED_DATE_TIME)));
+    actions.andExpect(jsonPath("$[0].addressLine1", is(ADDRESS_LINE_1)));
+    actions.andExpect(jsonPath("$[0].addressLine2", is(ADDRESS_LINE_2)));
+    actions.andExpect(jsonPath("$[0].addressLine3", is(ADDRESS_LINE_3)));
+    actions.andExpect(jsonPath("$[0].townName", is(TOWN)));
+    actions.andExpect(jsonPath("$[0].region", is(REGION)));
+    actions.andExpect(jsonPath("$[0].postcode", is(POSTCODE)));
+    actions.andExpect(jsonPath("$[0].ceOrgName", is(ORG_NAME)));
+
+    actions.andExpect(jsonPath("$[0].caseEvents[0].category", is(EVENT_CATEGORY)));
+    actions.andExpect(jsonPath("$[0].caseEvents[0].description", is(EVENT_DESCRIPTION)));
+    actions.andExpect(jsonPath("$[0].caseEvents[0].createdDateTime", is(EVENT_DATE_TIME)));
+
+    actions.andExpect(jsonPath("$[1].id", is(CASE_UUID_STRING)));
+    actions.andExpect(jsonPath("$[1].caseRef", is(CASE_REF)));
+    actions.andExpect(jsonPath("$[1].caseType", is(CASE_TYPE)));
+    actions.andExpect(jsonPath("$[1].createdDateTime", is(CASE_CREATED_DATE_TIME)));
+    actions.andExpect(jsonPath("$[1].addressLine1", is(ADDRESS_LINE_1)));
+    actions.andExpect(jsonPath("$[1].addressLine2", is(ADDRESS_LINE_2)));
+    actions.andExpect(jsonPath("$[1].addressLine3", is(ADDRESS_LINE_3)));
+    actions.andExpect(jsonPath("$[1].townName", is(TOWN)));
+    actions.andExpect(jsonPath("$[1].region", is(REGION)));
+    actions.andExpect(jsonPath("$[1].postcode", is(POSTCODE)));
+    actions.andExpect(jsonPath("$[1].ceOrgName", is(ORG_NAME)));
+
+    actions.andExpect(jsonPath("$[1].caseEvents[0].category", is(EVENT_CATEGORY)));
+    actions.andExpect(jsonPath("$[1].caseEvents[0].description", is(EVENT_DESCRIPTION)));
+    actions.andExpect(jsonPath("$[1].caseEvents[0].createdDateTime", is(EVENT_DATE_TIME)));
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointGetCcsCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointGetCcsCaseTest.java
@@ -1,7 +1,6 @@
 package uk.gov.ons.ctp.integration.contactcentresvc.endpoint;
 
 import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -20,11 +19,13 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.error.RestExceptionHandler;
 import uk.gov.ons.ctp.common.jackson.CustomObjectMapper;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
@@ -77,17 +78,6 @@ public final class CaseEndpointGetCcsCaseTest {
             .build();
   }
 
-//@Test
-//  public void getCaseById_GoodId() throws Exception {
-//    CaseDTO testCaseDTO = createResponseCaseDTO();
-//    Mockito.when(caseService.getCaseById(eq(uuid), any())).thenReturn(testCaseDTO);
-//
-//    ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid));
-//    actions.andExpect(status().isOk());
-//
-//    verifyStructureOfResultsActions(actions);
-//  }
-  
   @Test
   public void getCcsCaseByPostcode_PostcodeInList() throws Exception {
     List<CaseDTO> testCases = new ArrayList<>();
@@ -97,96 +87,114 @@ public final class CaseEndpointGetCcsCaseTest {
 
     ResultActions actions = mockMvc.perform(getJson("/cases/ccs/postcode/" + POSTCODE));
     actions.andExpect(status().isOk());
-    
+
     verifyStructureOfMultiResultsActions(actions);
   }
 
-//  @Test
-//  public void getCaseById_BadId() throws Exception {
-//    ResultActions actions = mockMvc.perform(getJson("/cases/123456789"));
-//    actions.andExpect(status().isBadRequest());
-//  }
-//
-//  @Test
-//  public void getCaseById_CaseEventsTrue() throws Exception {
-//    CaseDTO testCaseDTO = createResponseCaseDTO();
-//    Mockito.when(caseService.getCaseById(eq(uuid), any())).thenReturn(testCaseDTO);
-//
-//    ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid + "?caseEvents=1"));
-//    actions.andExpect(status().isOk());
-//
-//    verifyStructureOfResultsActions(actions);
-//  }
-//
-//  @Test
-//  public void getCaseById_CaseEventsDuff() throws Exception {
-//    ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid + "?caseEvents=maybe"));
-//    actions.andExpect(status().isBadRequest());
-//  }
-//
-//  @Test
-//  public void getCaseByRef_GoodRef() throws Exception {
-//    CaseDTO testCaseDTO = createResponseCaseDTO();
-//    Mockito.when(caseService.getCaseByCaseReference(eq(123456L), any())).thenReturn(testCaseDTO);
-//
-//    ResultActions actions = mockMvc.perform(getJson("/cases/ref/123456"));
-//    actions.andExpect(status().isOk());
-//
-//    verifyStructureOfResultsActions(actions);
-//  }
-//
-//  @Test
-//  public void getCaseByRef_BadRef() throws Exception {
-//    ResultActions actions = mockMvc.perform(getJson("/cases/ref/avg"));
-//    actions.andExpect(status().isBadRequest());
-//  }
-//
-//  @Test
-//  public void getCaseByUprn_GoodUPRN() throws Exception {
-//    List<CaseDTO> testCases = new ArrayList<>();
-//    testCases.add(createResponseCaseDTO());
-//    testCases.add(createResponseCaseDTO());
-//    UniquePropertyReferenceNumber expectedUprn = new UniquePropertyReferenceNumber(123456789012L);
-//    Mockito.when(caseService.getCaseByUPRN(eq(expectedUprn), any())).thenReturn(testCases);
-//
-//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012"));
-//    actions.andExpect(status().isOk());
-//
-//    verifyStructureOfMultiResultsActions(actions);
-//  }
-//
-//  @Test
-//  public void getCaseByUprn_UPRNTooLong() throws Exception {
-//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012345"));
-//    actions.andExpect(status().isBadRequest());
-//  }
-//
-//  @Test
-//  public void getCaseByUprn_BadUPRN() throws Exception {
-//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/A12345678901234"));
-//    actions.andExpect(status().isBadRequest());
-//  }
-//
-//  @Test
-//  public void getCaseByUprn_CaseEventsTrue() throws Exception {
-//    List<CaseDTO> testCases = new ArrayList<>();
-//    testCases.add(createResponseCaseDTO());
-//    testCases.add(createResponseCaseDTO());
-//    UniquePropertyReferenceNumber expectedUprn = new UniquePropertyReferenceNumber(123456789012L);
-//    Mockito.when(caseService.getCaseByUPRN(eq(expectedUprn), any())).thenReturn(testCases);
-//
-//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012?caseEvents=1"));
-//    actions.andExpect(status().isOk());
-//
-//    verifyStructureOfMultiResultsActions(actions);
-//  }
-//
-//  @Test
-//  public void getCaseByUprn_CaseEventsDuff() throws Exception {
-//    ResultActions actions = mockMvc.perform(getJson("/cases/uprn/12345678901234?caseEvents=maybe"));
-//    actions.andExpect(status().isBadRequest());
-//  }
-//
+  // @Test
+  // public void getCaseById_BadId() throws Exception {
+  // ResultActions actions = mockMvc.perform(getJson("/cases/123456789"));
+  // actions.andExpect(status().isBadRequest());
+  // }
+
+  @Test
+  public void getCcsCaseByPostcode_PostcodeNotInList() throws Exception {
+    ResponseStatusException ex =
+        new ResponseStatusException(
+            HttpStatus.BAD_REQUEST,
+            "Bad Request",
+            new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+    //    Mockito.doThrow(ex).when(caseService.getCCSCaseByPostcode(eq("GW12 AAC")));
+    Mockito.when(caseService.getCCSCaseByPostcode(eq("GW12 AAC"))).thenThrow(ex);
+    ResultActions actions = mockMvc.perform(getJson("/cases/ccs/postcode/GW12 AAC"));
+    actions.andExpect(status().isBadRequest());
+  }
+
+  //
+  // @Test
+  // public void getCaseById_CaseEventsTrue() throws Exception {
+  // CaseDTO testCaseDTO = createResponseCaseDTO();
+  // Mockito.when(caseService.getCaseById(eq(uuid), any())).thenReturn(testCaseDTO);
+  //
+  // ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid + "?caseEvents=1"));
+  // actions.andExpect(status().isOk());
+  //
+  // verifyStructureOfResultsActions(actions);
+  // }
+  //
+  // @Test
+  // public void getCaseById_CaseEventsDuff() throws Exception {
+  // ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid + "?caseEvents=maybe"));
+  // actions.andExpect(status().isBadRequest());
+  // }
+  //
+  // @Test
+  // public void getCaseByRef_GoodRef() throws Exception {
+  // CaseDTO testCaseDTO = createResponseCaseDTO();
+  // Mockito.when(caseService.getCaseByCaseReference(eq(123456L),
+  // any())).thenReturn(testCaseDTO);
+  //
+  // ResultActions actions = mockMvc.perform(getJson("/cases/ref/123456"));
+  // actions.andExpect(status().isOk());
+  //
+  // verifyStructureOfResultsActions(actions);
+  // }
+  //
+  // @Test
+  // public void getCaseByRef_BadRef() throws Exception {
+  // ResultActions actions = mockMvc.perform(getJson("/cases/ref/avg"));
+  // actions.andExpect(status().isBadRequest());
+  // }
+  //
+  // @Test
+  // public void getCaseByUprn_GoodUPRN() throws Exception {
+  // List<CaseDTO> testCases = new ArrayList<>();
+  // testCases.add(createResponseCaseDTO());
+  // testCases.add(createResponseCaseDTO());
+  // UniquePropertyReferenceNumber expectedUprn = new
+  // UniquePropertyReferenceNumber(123456789012L);
+  // Mockito.when(caseService.getCaseByUPRN(eq(expectedUprn), any())).thenReturn(testCases);
+  //
+  // ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012"));
+  // actions.andExpect(status().isOk());
+  //
+  // verifyStructureOfMultiResultsActions(actions);
+  // }
+  //
+  // @Test
+  // public void getCaseByUprn_UPRNTooLong() throws Exception {
+  // ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012345"));
+  // actions.andExpect(status().isBadRequest());
+  // }
+  //
+  // @Test
+  // public void getCaseByUprn_BadUPRN() throws Exception {
+  // ResultActions actions = mockMvc.perform(getJson("/cases/uprn/A12345678901234"));
+  // actions.andExpect(status().isBadRequest());
+  // }
+  //
+  // @Test
+  // public void getCaseByUprn_CaseEventsTrue() throws Exception {
+  // List<CaseDTO> testCases = new ArrayList<>();
+  // testCases.add(createResponseCaseDTO());
+  // testCases.add(createResponseCaseDTO());
+  // UniquePropertyReferenceNumber expectedUprn = new
+  // UniquePropertyReferenceNumber(123456789012L);
+  // Mockito.when(caseService.getCaseByUPRN(eq(expectedUprn), any())).thenReturn(testCases);
+  //
+  // ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012?caseEvents=1"));
+  // actions.andExpect(status().isOk());
+  //
+  // verifyStructureOfMultiResultsActions(actions);
+  // }
+  //
+  // @Test
+  // public void getCaseByUprn_CaseEventsDuff() throws Exception {
+  // ResultActions actions =
+  // mockMvc.perform(getJson("/cases/uprn/12345678901234?caseEvents=maybe"));
+  // actions.andExpect(status().isBadRequest());
+  // }
+  //
   private CaseDTO createResponseCaseDTO() throws ParseException {
     SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
 
@@ -216,23 +224,23 @@ public final class CaseEndpointGetCcsCaseTest {
     return fakeCaseDTO;
   }
 
-//  private void verifyStructureOfResultsActions(ResultActions actions) throws Exception {
-//    actions.andExpect(jsonPath("$[0].id", is(CASE_UUID_STRING)));
-//    actions.andExpect(jsonPath("$[0].caseRef", is(CASE_REF)));
-//    actions.andExpect(jsonPath("$[0].caseType", is(CASE_TYPE)));
-//    actions.andExpect(jsonPath("$[0].createdDateTime", is(CASE_CREATED_DATE_TIME)));
-//    actions.andExpect(jsonPath("$[0].addressLine1", is(ADDRESS_LINE_1)));
-//    actions.andExpect(jsonPath("$[0].addressLine2", is(ADDRESS_LINE_2)));
-//    actions.andExpect(jsonPath("$[0].addressLine3", is(ADDRESS_LINE_3)));
-//    actions.andExpect(jsonPath("$[0].townName", is(TOWN)));
-//    actions.andExpect(jsonPath("$[0].region", is(REGION)));
-//    actions.andExpect(jsonPath("$[0].postcode", is(POSTCODE)));
-//    actions.andExpect(jsonPath("$[0].ceOrgName", is(ORG_NAME)));
-//
-//    actions.andExpect(jsonPath("$[0].caseEvents[0].category", is(EVENT_CATEGORY)));
-//    actions.andExpect(jsonPath("$[0].caseEvents[0].description", is(EVENT_DESCRIPTION)));
-//    actions.andExpect(jsonPath("$[0].caseEvents[0].createdDateTime", is(EVENT_DATE_TIME)));
-//  }
+  // private void verifyStructureOfResultsActions(ResultActions actions) throws Exception {
+  // actions.andExpect(jsonPath("$[0].id", is(CASE_UUID_STRING)));
+  // actions.andExpect(jsonPath("$[0].caseRef", is(CASE_REF)));
+  // actions.andExpect(jsonPath("$[0].caseType", is(CASE_TYPE)));
+  // actions.andExpect(jsonPath("$[0].createdDateTime", is(CASE_CREATED_DATE_TIME)));
+  // actions.andExpect(jsonPath("$[0].addressLine1", is(ADDRESS_LINE_1)));
+  // actions.andExpect(jsonPath("$[0].addressLine2", is(ADDRESS_LINE_2)));
+  // actions.andExpect(jsonPath("$[0].addressLine3", is(ADDRESS_LINE_3)));
+  // actions.andExpect(jsonPath("$[0].townName", is(TOWN)));
+  // actions.andExpect(jsonPath("$[0].region", is(REGION)));
+  // actions.andExpect(jsonPath("$[0].postcode", is(POSTCODE)));
+  // actions.andExpect(jsonPath("$[0].ceOrgName", is(ORG_NAME)));
+  //
+  // actions.andExpect(jsonPath("$[0].caseEvents[0].category", is(EVENT_CATEGORY)));
+  // actions.andExpect(jsonPath("$[0].caseEvents[0].description", is(EVENT_DESCRIPTION)));
+  // actions.andExpect(jsonPath("$[0].caseEvents[0].createdDateTime", is(EVENT_DATE_TIME)));
+  // }
 
   private void verifyStructureOfMultiResultsActions(ResultActions actions) throws Exception {
     // This is not ideal - obvious duplication here - want to find a neater way of making the same

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointGetCcsCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/CaseEndpointGetCcsCaseTest.java
@@ -33,8 +33,8 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseEventDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 
 /**
- * Contact Centre Data Endpoint Unit tests. This class tests the get case endpoints, covering gets
- * based on uuid, ref and uprn.
+ * Contact Centre Data Endpoint Unit tests. This class tests the get ccs case endpoints, covering
+ * get ccs case by postcode.
  */
 public final class CaseEndpointGetCcsCaseTest {
 
@@ -59,8 +59,6 @@ public final class CaseEndpointGetCcsCaseTest {
   @Mock CaseService caseService;
 
   private MockMvc mockMvc;
-
-  private UUID uuid = UUID.randomUUID();
 
   /**
    * Set up of tests
@@ -91,11 +89,15 @@ public final class CaseEndpointGetCcsCaseTest {
     verifyStructureOfMultiResultsActions(actions);
   }
 
-  // @Test
-  // public void getCaseById_BadId() throws Exception {
-  // ResultActions actions = mockMvc.perform(getJson("/cases/123456789"));
-  // actions.andExpect(status().isBadRequest());
-  // }
+  @Test
+  public void getCcsCaseByPostcode_PostcodeInListButNotInRM() throws Exception {
+    ResponseStatusException ex =
+        new ResponseStatusException(
+            HttpStatus.NOT_FOUND, "Not Found", new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    Mockito.when(caseService.getCCSCaseByPostcode(eq("GW12 AAB"))).thenThrow(ex);
+    ResultActions actions = mockMvc.perform(getJson("/cases/ccs/postcode/GW12 AAB"));
+    actions.andExpect(status().isNotFound());
+  }
 
   @Test
   public void getCcsCaseByPostcode_PostcodeNotInList() throws Exception {
@@ -104,97 +106,11 @@ public final class CaseEndpointGetCcsCaseTest {
             HttpStatus.BAD_REQUEST,
             "Bad Request",
             new HttpClientErrorException(HttpStatus.BAD_REQUEST));
-    //    Mockito.doThrow(ex).when(caseService.getCCSCaseByPostcode(eq("GW12 AAC")));
     Mockito.when(caseService.getCCSCaseByPostcode(eq("GW12 AAC"))).thenThrow(ex);
     ResultActions actions = mockMvc.perform(getJson("/cases/ccs/postcode/GW12 AAC"));
     actions.andExpect(status().isBadRequest());
   }
 
-  //
-  // @Test
-  // public void getCaseById_CaseEventsTrue() throws Exception {
-  // CaseDTO testCaseDTO = createResponseCaseDTO();
-  // Mockito.when(caseService.getCaseById(eq(uuid), any())).thenReturn(testCaseDTO);
-  //
-  // ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid + "?caseEvents=1"));
-  // actions.andExpect(status().isOk());
-  //
-  // verifyStructureOfResultsActions(actions);
-  // }
-  //
-  // @Test
-  // public void getCaseById_CaseEventsDuff() throws Exception {
-  // ResultActions actions = mockMvc.perform(getJson("/cases/" + uuid + "?caseEvents=maybe"));
-  // actions.andExpect(status().isBadRequest());
-  // }
-  //
-  // @Test
-  // public void getCaseByRef_GoodRef() throws Exception {
-  // CaseDTO testCaseDTO = createResponseCaseDTO();
-  // Mockito.when(caseService.getCaseByCaseReference(eq(123456L),
-  // any())).thenReturn(testCaseDTO);
-  //
-  // ResultActions actions = mockMvc.perform(getJson("/cases/ref/123456"));
-  // actions.andExpect(status().isOk());
-  //
-  // verifyStructureOfResultsActions(actions);
-  // }
-  //
-  // @Test
-  // public void getCaseByRef_BadRef() throws Exception {
-  // ResultActions actions = mockMvc.perform(getJson("/cases/ref/avg"));
-  // actions.andExpect(status().isBadRequest());
-  // }
-  //
-  // @Test
-  // public void getCaseByUprn_GoodUPRN() throws Exception {
-  // List<CaseDTO> testCases = new ArrayList<>();
-  // testCases.add(createResponseCaseDTO());
-  // testCases.add(createResponseCaseDTO());
-  // UniquePropertyReferenceNumber expectedUprn = new
-  // UniquePropertyReferenceNumber(123456789012L);
-  // Mockito.when(caseService.getCaseByUPRN(eq(expectedUprn), any())).thenReturn(testCases);
-  //
-  // ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012"));
-  // actions.andExpect(status().isOk());
-  //
-  // verifyStructureOfMultiResultsActions(actions);
-  // }
-  //
-  // @Test
-  // public void getCaseByUprn_UPRNTooLong() throws Exception {
-  // ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012345"));
-  // actions.andExpect(status().isBadRequest());
-  // }
-  //
-  // @Test
-  // public void getCaseByUprn_BadUPRN() throws Exception {
-  // ResultActions actions = mockMvc.perform(getJson("/cases/uprn/A12345678901234"));
-  // actions.andExpect(status().isBadRequest());
-  // }
-  //
-  // @Test
-  // public void getCaseByUprn_CaseEventsTrue() throws Exception {
-  // List<CaseDTO> testCases = new ArrayList<>();
-  // testCases.add(createResponseCaseDTO());
-  // testCases.add(createResponseCaseDTO());
-  // UniquePropertyReferenceNumber expectedUprn = new
-  // UniquePropertyReferenceNumber(123456789012L);
-  // Mockito.when(caseService.getCaseByUPRN(eq(expectedUprn), any())).thenReturn(testCases);
-  //
-  // ResultActions actions = mockMvc.perform(getJson("/cases/uprn/123456789012?caseEvents=1"));
-  // actions.andExpect(status().isOk());
-  //
-  // verifyStructureOfMultiResultsActions(actions);
-  // }
-  //
-  // @Test
-  // public void getCaseByUprn_CaseEventsDuff() throws Exception {
-  // ResultActions actions =
-  // mockMvc.perform(getJson("/cases/uprn/12345678901234?caseEvents=maybe"));
-  // actions.andExpect(status().isBadRequest());
-  // }
-  //
   private CaseDTO createResponseCaseDTO() throws ParseException {
     SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSX");
 
@@ -224,27 +140,7 @@ public final class CaseEndpointGetCcsCaseTest {
     return fakeCaseDTO;
   }
 
-  // private void verifyStructureOfResultsActions(ResultActions actions) throws Exception {
-  // actions.andExpect(jsonPath("$[0].id", is(CASE_UUID_STRING)));
-  // actions.andExpect(jsonPath("$[0].caseRef", is(CASE_REF)));
-  // actions.andExpect(jsonPath("$[0].caseType", is(CASE_TYPE)));
-  // actions.andExpect(jsonPath("$[0].createdDateTime", is(CASE_CREATED_DATE_TIME)));
-  // actions.andExpect(jsonPath("$[0].addressLine1", is(ADDRESS_LINE_1)));
-  // actions.andExpect(jsonPath("$[0].addressLine2", is(ADDRESS_LINE_2)));
-  // actions.andExpect(jsonPath("$[0].addressLine3", is(ADDRESS_LINE_3)));
-  // actions.andExpect(jsonPath("$[0].townName", is(TOWN)));
-  // actions.andExpect(jsonPath("$[0].region", is(REGION)));
-  // actions.andExpect(jsonPath("$[0].postcode", is(POSTCODE)));
-  // actions.andExpect(jsonPath("$[0].ceOrgName", is(ORG_NAME)));
-  //
-  // actions.andExpect(jsonPath("$[0].caseEvents[0].category", is(EVENT_CATEGORY)));
-  // actions.andExpect(jsonPath("$[0].caseEvents[0].description", is(EVENT_DESCRIPTION)));
-  // actions.andExpect(jsonPath("$[0].caseEvents[0].createdDateTime", is(EVENT_DATE_TIME)));
-  // }
-
   private void verifyStructureOfMultiResultsActions(ResultActions actions) throws Exception {
-    // This is not ideal - obvious duplication here - want to find a neater way of making the same
-    // assertions repeatedly
     actions.andExpect(jsonPath("$[0].id", is(CASE_UUID_STRING)));
     actions.andExpect(jsonPath("$[0].caseRef", is(CASE_REF)));
     actions.andExpect(jsonPath("$[0].caseType", is(CASE_TYPE)));

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
@@ -32,8 +32,8 @@ import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTestBase {
 
   private static final UUID CASE_ID = UUID.fromString("b7565b5e-1396-4965-91a2-918c0d3642ed");
-  private static final String POSTCODE_IN_CCS_SET = "GW12AAA";
-  private static final String POSTCODE_NOT_IN_CCS_SET = "GW12AAC";
+  private static final String POSTCODE_IN_CCS_SET = "GW12 AAA";
+  private static final String POSTCODE_NOT_IN_CCS_SET = "GW12 AAC";
   List<CaseContainerDTO> casesFromRm;
 
   @Before

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
@@ -2,10 +2,8 @@ package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
@@ -31,18 +29,8 @@ import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
  */
 @RunWith(MockitoJUnitRunner.class)
 public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTestBase {
-  // private static final String AN_ESTAB_UPRN = "334111111111";
-  // private static final UniquePropertyReferenceNumber UPRN =
-  // new UniquePropertyReferenceNumber(334999999999L);
-  //
-  // // the actual census name & id as per the application.yml and also RM
-  // private static final String SURVEY_NAME = "CENSUS";
-  // private static final String COLLECTION_EXERCISE_ID = "34d7f3bb-91c9-45d0-bb2d-90afce4fc790";
-  //
-  private static final UUID CASE_ID = UUID.fromString("b7565b5e-1396-4965-91a2-918c0d3642ed");
-  // private static final UUID CACHED_CASE_ID_1 =
-  // UUID.fromString("c46e5dd4-4b17-45ac-a034-0e514e8592c0");
 
+  private static final UUID CASE_ID = UUID.fromString("b7565b5e-1396-4965-91a2-918c0d3642ed");
   private static final String POSTCODE_IN_CCS_SET = "GW12AAA";
   private static final String POSTCODE_NOT_IN_CCS_SET = "GW12AAC";
   List<CaseContainerDTO> casesFromRm;
@@ -66,15 +54,26 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
   @Test
   public void testGetCcsCaseByPostcode_withPostcodeInRMAndInCCSPostcodes() throws CTPException {
     casesFromRm.get(1).setPostcode(POSTCODE_IN_CCS_SET);
-    // mockCasesFromRm();
     when(caseServiceClient.getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET))).thenReturn(casesFromRm);
     CaseDTO result = getCasesByPostcode(POSTCODE_IN_CCS_SET);
     assertEquals(CASE_ID, result.getId());
   }
 
   @Test
-  public void testGetCcsCaseByPostcode_withPostcodeInRMAndNotInCCSPostcodes() throws CTPException {
-    // casesFromRm.get(1).setPostcode(POSTCODE_NOT_IN_CCS_SET);
+  public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndInCCSPostcodes() throws CTPException {
+    doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
+        .when(caseServiceClient)
+        .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));
+    try {
+      getCasesByPostcode(POSTCODE_IN_CCS_SET);
+      fail();
+    } catch (ResponseStatusException notFound) {
+      assertEquals(HttpStatus.NOT_FOUND, notFound.getStatus());
+    }
+  }
+
+  @Test
+  public void testGetCcsCaseByPostcode_withPostcodeNotInCCSPostcodes() throws CTPException {
     try {
       getCasesByPostcode(POSTCODE_NOT_IN_CCS_SET);
       fail();
@@ -83,361 +82,8 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
     }
   }
 
-  @Test
-  public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndInCCSPostcodes() throws CTPException {
-    //    casesFromRm.get(1).setPostcode(POSTCODE_IN_CCS_SET);
-    // mockCasesFromRm();
-    //
-    // when(caseServiceClient.getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET))).thenReturn(casesFromRm);
-    //    ResponseStatusException ex = new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-    //        "Resource Not Found", new HttpClientErrorException(HttpStatus.NOT_FOUND));
-    //    Mockito.doThrow(ex).when(caseServiceClient.getCcsCaseByPostcode(POSTCODE_IN_CCS_SET));
-    doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
-        .when(caseServiceClient)
-        .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));
-    try {
-      getCasesByPostcode(POSTCODE_IN_CCS_SET);
-      fail();
-    } catch (ResponseStatusException notFound) {
-      //      assertTrue(notFound.getMessage().contains(Fault.RESOURCE_NOT_FOUND.toString()));
-      assertEquals(HttpStatus.NOT_FOUND, notFound.getStatus());
-    }
-  }
-  //
-  // @Test
-  // public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndNotInCCSPostcodes() {
-  //
-  // }
-
-  // @Test
-  // public void testGetCaseByUprn_withCaseDetailsForCaseTypeHH() throws Exception {
-  // casesFromRm.get(0).setCaseType(CaseType.HH.name());
-
-  // CaseDTO result = getCasesByUprn(true);
-  // verifyNonCachedCase(result, true, 0);
-  // }
-  //
-  // @Test
-  // public void testGetCaseByUprn_withCaseDetailsForCaseTypeCE() throws Exception {
-  // casesFromRm.get(1).setCaseType(CaseType.CE.name());
-  // setLastUpdated(casesFromRm.get(0), 2020, 5, 14);
-  // setLastUpdated(casesFromRm.get(1), 2020, 5, 15);
-  // mockCasesFromRm();
-  // CaseDTO result = getCasesByUprn(true);
-  // verifyNonCachedCase(result, true, 1);
-  // }
-  //
-  // @Test
-  // public void testGetCaseByUprn_withNoCaseDetailsForCaseTypeHH() throws Exception {
-  // casesFromRm.get(0).setCaseType(CaseType.HH.name());
-  // mockCasesFromRm();
-  // CaseDTO result = getCasesByUprn(false);
-  // verifyNonCachedCase(result, false, 0);
-  // }
-
-  // @Test
-  // public void testGetCaseByUprn_withNoCaseDetailsForCaseTypeCE() throws Exception {
-  // casesFromRm.get(1).setCaseType(CaseType.CE.name());
-  // setLastUpdated(casesFromRm.get(0), 2020, 5, 14);
-  // setLastUpdated(casesFromRm.get(1), 2020, 5, 15);
-  // mockCasesFromRm();
-  // CaseDTO result = getCasesByUprn(false);
-  // verifyNonCachedCase(result, false, 1);
-  // }
-
-  // @Test
-  // public void testGetCaseByUprn_householdIndividualCase_emptyResultSet_noCachedCase()
-  // throws Exception {
-  //
-  // casesFromRm.get(0).setCaseType("HI");
-  // casesFromRm.get(1).setCaseType("HI");
-  //
-  // mockCasesFromRm();
-  // mockNothingInTheCache();
-  // mockAddressFromAI();
-  //
-  // CaseDTO result = getCasesByUprn(false);
-  // verifyNewCase(result);
-  // }
-
-  // @Test
-  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_HH() throws Exception {
-  //
-  // doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND)).when(caseServiceClient)
-  // .getCaseByUprn(eq(UPRN.getValue()), any());
-  //
-  // mockNothingInTheCache();
-  // mockAddressFromAI();
-  //
-  // CaseDTO result = getCasesByUprn(false);
-  // verifyNewCase(result);
-  // }
-
-  // private void verifyCreatedNewCase(String estabType) throws Exception {
-  // addressFromAI.setCensusEstabType("marina");
-  //
-  // mockNothingInRm();
-  // mockNothingInTheCache();
-  // mockAddressFromAI();
-  //
-  // CaseDTO result = getCasesByUprn(false);
-  // verifyNewCase(result);
-  // }
-
-  // @Test
-  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_SPG() throws Exception {
-  // verifyCreatedNewCase("marina");
-  // }
-  //
-  // @Test
-  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_CE() throws Exception {
-  // verifyCreatedNewCase("CARE HOME");
-  // }
-
-  // @Test
-  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_NA() throws Exception {
-  // verifyCreatedNewCase("NA");
-  // }
-
-  // @Test(expected = CTPException.class)
-  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_addressServiceNotFound()
-  // throws Exception {
-  //
-  // mockNothingInRm();
-  // mockNothingInTheCache();
-  //
-  // doThrow(new
-  // CTPException(Fault.RESOURCE_NOT_FOUND)).when(addressSvc).uprnQuery(UPRN.getValue());
-  // target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(false));
-  // verify(caseServiceClient, times(1)).getCaseByUprn(any(Long.class), any(Boolean.class));
-  // verifyHasReadCachedCases();
-  // verifyNotWrittenCachedCase();
-  // verify(addressSvc, times(1)).uprnQuery(anyLong());
-  // verifyEventNotSent();
-  // }
-  //
-  // @Test(expected = ResponseStatusException.class)
-  // public void
-  // testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_addressSvcRestClientException()
-  // throws Exception {
-  //
-  // mockNothingInRm();
-  // mockNothingInTheCache();
-  //
-  // doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT)).when(addressSvc)
-  // .uprnQuery(eq(UPRN.getValue()));
-  //
-  // target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(false));
-  // }
-
-  // @Test(expected = CTPException.class)
-  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_scottishAddress()
-  // throws Exception {
-  //
-  // addressFromAI.setCountryCode("S");
-  //
-  // mockNothingInRm();
-  // mockNothingInTheCache();
-  // mockAddressFromAI();
-  //
-  // target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(false));
-  // }
-
-  // @Test(expected = CTPException.class)
-  // public void testGetCaseByUprn_caseSvcNotFoundResponse_NoCachedCase_RetriesExhausted()
-  // throws Exception {
-  //
-  // mockNothingInRm();
-  // mockNothingInTheCache();
-  // mockAddressFromAI();
-  //
-  // doThrow(new CTPException(Fault.SYSTEM_ERROR, new Exception(), "Retries exhausted"))
-  // .when(dataRepo).writeCachedCase(any());
-  // target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(false));
-  // }
-
-  // @Test
-  // public void testGetCaseByUprn_mixedCaseTypes() throws Exception {
-  // casesFromRm.get(0).setCaseType("HI"); // Household Individual case
-  // mockCasesFromRm();
-  // CaseDTO result = getCasesByUprn(true);
-  // verifyNonCachedCase(result, true, 1);
-  // }
-
-  // @Test
-  // public void testGetCaseByUprn_caseSPG() throws Exception {
-  // casesFromRm.get(0).setCaseType("SPG");
-  // mockCasesFromRm();
-  // CaseDTO result = getCasesByUprn(true);
-  // verifyNonCachedCase(result, true, 0);
-  // }
-
-  // @Test
-  // public void testGetCaseByUprn_caseHH() throws Exception {
-  // casesFromRm.get(0).setCaseType("HH");
-  // mockCasesFromRm();
-  // CaseDTO result = getCasesByUprn(true);
-  // verifyNonCachedCase(result, true, 0);
-  // }
-  //
-  // @Test
-  // public void shouldGetSecureEstablishmentByUprn() throws Exception {
-  // setLastUpdated(casesFromRm.get(0), 2020, 5, 14);
-  // setLastUpdated(casesFromRm.get(1), 2020, 5, 15);
-  // mockCasesFromRm();
-  // CaseDTO result = getCasesByUprn(false);
-  // assertTrue(result.isSecureEstablishment());
-  // assertEquals(new UniquePropertyReferenceNumber(AN_ESTAB_UPRN), result.getEstabUprn());
-  // }
-  //
-  // // --- results from both RM and cache ...
-  //
-  // @Test
-  // public void shouldGetLatestFromCacheWhenResultsFromBothRmAndCache() throws Exception {
-  // mockCasesFromRm();
-  // mockCasesFromCache();
-  // CaseDTO result = getCasesByUprn(false);
-  // assertEquals(CACHED_CASE_ID_1, result.getId());
-  // }
-
-  // @Test
-  // public void shouldGetLatestFromCacheWhenResultsFromBothRmAndCacheWithSmallTimeDifference()
-  // throws Exception {
-  // casesFromCache.get(0).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 2, 3, 10, 4, 6)));
-  // casesFromCache.get(1).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 2, 3, 10, 4, 5)));
-  // casesFromRm.get(0).setLastUpdated(utcDate(LocalDateTime.of(2020, 1, 4, 0, 0)));
-  // casesFromRm.get(1).setLastUpdated(utcDate(LocalDateTime.of(2019, 12, 12, 0, 0)));
-  // mockCasesFromRm();
-  // mockCasesFromCache();
-  // CaseDTO result = getCasesByUprn(false);
-  // assertEquals(CACHED_CASE_ID_0, result.getId());
-  // }
-  //
-  // @Test
-  // public void shouldGetLatestFromRmWhenResultsFromBothRmAndCache() throws Exception {
-  // casesFromCache.get(0).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 1, 2, 0, 0)));
-  // casesFromCache.get(1).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 1, 3, 0, 0)));
-  // casesFromRm.get(0).setLastUpdated(utcDate(LocalDateTime.of(2020, 1, 1, 0, 0)));
-  // casesFromRm.get(1).setLastUpdated(utcDate(LocalDateTime.of(2020, 1, 23, 0, 0)));
-  // mockCasesFromRm();
-  // mockCasesFromCache();
-  // CaseDTO result = getCasesByUprn(false);
-  // assertEquals(UUID_1, result.getId());
-  // }
-  //
-  // @Test
-  // public void shouldGetLatestFromRmWhenResultsFromBothRmAndCacheWithSmallTimeDifferences()
-  // throws Exception {
-  // casesFromCache.get(0).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 1, 3, 0, 0)));
-  // casesFromCache.get(1).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 2, 3, 10, 4, 5)));
-  // casesFromRm.get(0).setLastUpdated(utcDate(LocalDateTime.of(2020, 1, 1, 0, 0)));
-  // casesFromRm.get(1).setLastUpdated(utcDate(LocalDateTime.of(2020, 2, 3, 10, 4, 6)));
-  // mockCasesFromRm();
-  // mockCasesFromCache();
-  // CaseDTO result = getCasesByUprn(false);
-  // assertEquals(UUID_1, result.getId());
-  // }
-
-  // ---- helpers methods below ---
-
-  // private void mockCasesFromRm() {
-  // when(caseServiceClient.getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET))).thenReturn(casesFromRm);
-  // }
-
-  private void mockNothingInRm() {
-    doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
-        .when(caseServiceClient)
-        .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));
-  }
-
-  private void verifyCallToGetCasesFromRm() {
-    verify(caseServiceClient).getCaseByUprn(any(Long.class), any(Boolean.class));
-  }
-
-  // private void verifyHasReadCachedCases() throws Exception {
-  // verify(dataRepo).readCachedCasesByUprn(any(UniquePropertyReferenceNumber.class));
-  // }
-  //
-  // private CachedCase verifyHasWrittenCachedCase() throws Exception {
-  // ArgumentCaptor<CachedCase> cachedCaseCaptor = ArgumentCaptor.forClass(CachedCase.class);
-  // verify(dataRepo).writeCachedCase(cachedCaseCaptor.capture());
-  // return cachedCaseCaptor.getValue();
-  // }
-  //
-  // // private void mockAddressFromAI() throws Exception {
-  // // when(addressSvc.uprnQuery(UPRN.getValue())).thenReturn(addressFromAI);
-  // // }
-  //
-  // private void verifyNonCachedCase(CaseDTO results, boolean caseEventsExpected, int dataIndex)
-  // throws Exception {
-  // CaseDTO expectedCaseResult =
-  // createExpectedCaseDTO(casesFromRm.get(dataIndex), caseEventsExpected);
-  //
-  // verifyCase(results, expectedCaseResult, caseEventsExpected);
-  // verifyHasReadCachedCases();
-  // }
-
-  // private void verifyNewCase(CaseDTO result) throws Exception {
-  //
-  // verifyCallToGetCasesFromRm();
-  // verifyHasReadCachedCases();
-  // verify(addressSvc, times(1)).uprnQuery(anyLong());
-  //
-  // // Verify content of case written to Firestore
-  // CachedCase capturedCase = verifyHasWrittenCachedCase();
-  // verifyCachedCaseContent(result.getId(), CaseType.HH, capturedCase);
-  //
-  // // Verify response
-  // CachedCase cachedCase = mapperFacade.map(addressFromAI, CachedCase.class);
-  // cachedCase.setId(result.getId().toString());
-  // verifyCaseDTOContent(cachedCase, CaseType.HH.name(), false, result);
-  //
-  // // Verify the NewAddressEvent
-  // CollectionCaseNewAddress newAddress =
-  // mapperFacade.map(addressFromAI, CollectionCaseNewAddress.class);
-  // newAddress.setId(cachedCase.getId());
-  // verifyNewAddressEventSent(addressFromAI.getCensusAddressType(),
-  // addressFromAI.getCensusEstabType(), newAddress);
-  // }
-
-  // private void verifyCachedCaseContent(UUID expectedId, CaseType expectedCaseType,
-  // CachedCase expectedCase) {
-  // assertEquals(expectedId.toString(), expectedCase.getId());
-  // assertEquals(addressFromAI.getUprn(), expectedCase.getUprn());
-  // assertEquals(addressFromAI.getAddressLine1(), expectedCase.getAddressLine1());
-  // assertEquals(addressFromAI.getAddressLine2(), expectedCase.getAddressLine2());
-  // assertEquals(addressFromAI.getAddressLine3(), expectedCase.getAddressLine3());
-  // assertEquals(addressFromAI.getTownName(), expectedCase.getTownName());
-  // assertEquals(addressFromAI.getPostcode(), expectedCase.getPostcode());
-  // assertEquals(addressFromAI.getCensusAddressType(), expectedCase.getAddressType());
-  // assertEquals(expectedCaseType, expectedCase.getCaseType());
-  // assertEquals(addressFromAI.getCensusEstabType(), expectedCase.getEstabType());
-  // assertEquals(addressFromAI.getCountryCode(), expectedCase.getRegion());
-  // assertEquals(addressFromAI.getOrganisationName(), expectedCase.getCeOrgName());
-  // assertEquals(0, expectedCase.getCaseEvents().size());
-  // }
-
-  // private void verifyCaseDTOContent(CachedCase cachedCase, String expectedCaseType,
-  // boolean isSecureEstablishment, CaseDTO actualCaseDto) {
-  // CaseDTO expectedNewCaseResult = mapperFacade.map(cachedCase, CaseDTO.class);
-  // expectedNewCaseResult.setCreatedDateTime(actualCaseDto.getCreatedDateTime());
-  // expectedNewCaseResult.setCaseType(expectedCaseType);
-  // expectedNewCaseResult.setEstabType(EstabType.forCode(cachedCase.getEstabType()));
-  // expectedNewCaseResult.setSecureEstablishment(isSecureEstablishment);
-  // expectedNewCaseResult.setAllowedDeliveryChannels(Arrays.asList(DeliveryChannel.values()));
-  // expectedNewCaseResult.setCaseEvents(Collections.emptyList());
-  // assertEquals(expectedNewCaseResult, actualCaseDto);
-  // }
-
-  // private CaseDTO getCasesByUprn(boolean caseEvents) throws CTPException {
-  // List<CaseDTO> results = target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(caseEvents));
-  // assertEquals(1, results.size());
-  // return results.get(0);
-  // }
-
   private CaseDTO getCasesByPostcode(String postcode) throws CTPException {
     List<CaseDTO> results = target.getCCSCaseByPostcode(postcode);
-    // assertEquals(2, results.size());
     return results.get(0);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
@@ -1,0 +1,437 @@
+package uk.gov.ons.ctp.integration.contactcentresvc.service.impl;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+import uk.gov.ons.ctp.common.FixtureHelper;
+import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
+import uk.gov.ons.ctp.common.error.CTPException;
+import uk.gov.ons.ctp.common.error.CTPException.Fault;
+import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseQueryRequestDTO;
+import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
+
+/**
+ * Unit Test {@link CaseService#getCaseByUPRN(UniquePropertyReferenceNumber, CaseQueryRequestDTO)
+ * getCaseByUPRN}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTestBase {
+  // private static final String AN_ESTAB_UPRN = "334111111111";
+  // private static final UniquePropertyReferenceNumber UPRN =
+  // new UniquePropertyReferenceNumber(334999999999L);
+  //
+  // // the actual census name & id as per the application.yml and also RM
+  // private static final String SURVEY_NAME = "CENSUS";
+  // private static final String COLLECTION_EXERCISE_ID = "34d7f3bb-91c9-45d0-bb2d-90afce4fc790";
+  //
+  private static final UUID CASE_ID = UUID.fromString("b7565b5e-1396-4965-91a2-918c0d3642ed");
+  // private static final UUID CACHED_CASE_ID_1 =
+  // UUID.fromString("c46e5dd4-4b17-45ac-a034-0e514e8592c0");
+
+  private static final String POSTCODE_IN_CCS_SET = "GW12AAA";
+  private static final String POSTCODE_NOT_IN_CCS_SET = "GW12AAC";
+  List<CaseContainerDTO> casesFromRm;
+
+  @Before
+  public void setup() {
+    mockCcsPostcodes();
+
+    // when(appConfig.getChannel()).thenReturn(Channel.CC);
+    // when(appConfig.getSurveyName()).thenReturn(SURVEY_NAME);
+    // when(appConfig.getCollectionExerciseId()).thenReturn(COLLECTION_EXERCISE_ID);
+
+    casesFromRm = FixtureHelper.loadPackageFixtures(CaseContainerDTO[].class);
+  }
+
+  //  @Test(expected = ResponseStatusException.class)
+  //  public void testGetCcsCaseByPostcode_caseSvcRestClientException() throws Exception {
+  //
+  //    doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT)).when(caseServiceClient)
+  //        .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));
+  //
+  //    target.getCCSCaseByPostcode(POSTCODE_IN_CCS_SET);
+  //  }
+
+  @Test
+  public void testGetCcsCaseByPostcode_withPostcodeInRMAndInCCSPostcodes() throws CTPException {
+    casesFromRm.get(1).setPostcode(POSTCODE_IN_CCS_SET);
+    // mockCasesFromRm();
+    when(caseServiceClient.getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET))).thenReturn(casesFromRm);
+    CaseDTO result = getCasesByPostcode(POSTCODE_IN_CCS_SET);
+    assertEquals(CASE_ID, result.getId());
+  }
+
+  @Test
+  public void testGetCcsCaseByPostcode_withPostcodeInRMAndNotInCCSPostcodes() throws CTPException {
+    casesFromRm.get(1).setPostcode(POSTCODE_NOT_IN_CCS_SET);
+    // mockCasesFromRm();
+    //
+    // when(caseServiceClient.getCcsCaseByPostcode(eq(POSTCODE_NOT_IN_CCS_SET))).thenReturn(casesFromRm);
+    //    ResponseStatusException ex = new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+    //        "Bad Request", new HttpClientErrorException(HttpStatus.BAD_REQUEST));
+    //    Mockito.doThrow(ex).when(caseServiceClient.getCcsCaseByPostcode(POSTCODE_NOT_IN_CCS_SET));
+    try {
+      CaseDTO result = getCasesByPostcode(POSTCODE_NOT_IN_CCS_SET);
+      fail();
+    } catch (CTPException badRequest) {
+      assertEquals(Fault.BAD_REQUEST, badRequest.getFault());
+    }
+  }
+
+  //  @Test
+  //  public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndInCCSPostcodes() {
+  //
+  //  }
+  //
+  //  @Test
+  //  public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndNotInCCSPostcodes() {
+  //
+  //  }
+
+  // @Test
+  // public void testGetCaseByUprn_withCaseDetailsForCaseTypeHH() throws Exception {
+  // casesFromRm.get(0).setCaseType(CaseType.HH.name());
+
+  // CaseDTO result = getCasesByUprn(true);
+  // verifyNonCachedCase(result, true, 0);
+  // }
+  //
+  // @Test
+  // public void testGetCaseByUprn_withCaseDetailsForCaseTypeCE() throws Exception {
+  // casesFromRm.get(1).setCaseType(CaseType.CE.name());
+  // setLastUpdated(casesFromRm.get(0), 2020, 5, 14);
+  // setLastUpdated(casesFromRm.get(1), 2020, 5, 15);
+  // mockCasesFromRm();
+  // CaseDTO result = getCasesByUprn(true);
+  // verifyNonCachedCase(result, true, 1);
+  // }
+  //
+  // @Test
+  // public void testGetCaseByUprn_withNoCaseDetailsForCaseTypeHH() throws Exception {
+  // casesFromRm.get(0).setCaseType(CaseType.HH.name());
+  // mockCasesFromRm();
+  // CaseDTO result = getCasesByUprn(false);
+  // verifyNonCachedCase(result, false, 0);
+  // }
+
+  // @Test
+  // public void testGetCaseByUprn_withNoCaseDetailsForCaseTypeCE() throws Exception {
+  // casesFromRm.get(1).setCaseType(CaseType.CE.name());
+  // setLastUpdated(casesFromRm.get(0), 2020, 5, 14);
+  // setLastUpdated(casesFromRm.get(1), 2020, 5, 15);
+  // mockCasesFromRm();
+  // CaseDTO result = getCasesByUprn(false);
+  // verifyNonCachedCase(result, false, 1);
+  // }
+
+  // @Test
+  // public void testGetCaseByUprn_householdIndividualCase_emptyResultSet_noCachedCase()
+  // throws Exception {
+  //
+  // casesFromRm.get(0).setCaseType("HI");
+  // casesFromRm.get(1).setCaseType("HI");
+  //
+  // mockCasesFromRm();
+  // mockNothingInTheCache();
+  // mockAddressFromAI();
+  //
+  // CaseDTO result = getCasesByUprn(false);
+  // verifyNewCase(result);
+  // }
+
+  // @Test
+  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_HH() throws Exception {
+  //
+  // doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND)).when(caseServiceClient)
+  // .getCaseByUprn(eq(UPRN.getValue()), any());
+  //
+  // mockNothingInTheCache();
+  // mockAddressFromAI();
+  //
+  // CaseDTO result = getCasesByUprn(false);
+  // verifyNewCase(result);
+  // }
+
+  // private void verifyCreatedNewCase(String estabType) throws Exception {
+  // addressFromAI.setCensusEstabType("marina");
+  //
+  // mockNothingInRm();
+  // mockNothingInTheCache();
+  // mockAddressFromAI();
+  //
+  // CaseDTO result = getCasesByUprn(false);
+  // verifyNewCase(result);
+  // }
+
+  // @Test
+  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_SPG() throws Exception {
+  // verifyCreatedNewCase("marina");
+  // }
+  //
+  // @Test
+  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_CE() throws Exception {
+  // verifyCreatedNewCase("CARE HOME");
+  // }
+
+  // @Test
+  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_NA() throws Exception {
+  // verifyCreatedNewCase("NA");
+  // }
+
+  // @Test(expected = CTPException.class)
+  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_addressServiceNotFound()
+  // throws Exception {
+  //
+  // mockNothingInRm();
+  // mockNothingInTheCache();
+  //
+  // doThrow(new
+  // CTPException(Fault.RESOURCE_NOT_FOUND)).when(addressSvc).uprnQuery(UPRN.getValue());
+  // target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(false));
+  // verify(caseServiceClient, times(1)).getCaseByUprn(any(Long.class), any(Boolean.class));
+  // verifyHasReadCachedCases();
+  // verifyNotWrittenCachedCase();
+  // verify(addressSvc, times(1)).uprnQuery(anyLong());
+  // verifyEventNotSent();
+  // }
+  //
+  // @Test(expected = ResponseStatusException.class)
+  // public void
+  // testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_addressSvcRestClientException()
+  // throws Exception {
+  //
+  // mockNothingInRm();
+  // mockNothingInTheCache();
+  //
+  // doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT)).when(addressSvc)
+  // .uprnQuery(eq(UPRN.getValue()));
+  //
+  // target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(false));
+  // }
+
+  // @Test(expected = CTPException.class)
+  // public void testGetCaseByUprn_caseSvcNotFoundResponse_noCachedCase_scottishAddress()
+  // throws Exception {
+  //
+  // addressFromAI.setCountryCode("S");
+  //
+  // mockNothingInRm();
+  // mockNothingInTheCache();
+  // mockAddressFromAI();
+  //
+  // target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(false));
+  // }
+
+  // @Test(expected = CTPException.class)
+  // public void testGetCaseByUprn_caseSvcNotFoundResponse_NoCachedCase_RetriesExhausted()
+  // throws Exception {
+  //
+  // mockNothingInRm();
+  // mockNothingInTheCache();
+  // mockAddressFromAI();
+  //
+  // doThrow(new CTPException(Fault.SYSTEM_ERROR, new Exception(), "Retries exhausted"))
+  // .when(dataRepo).writeCachedCase(any());
+  // target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(false));
+  // }
+
+  // @Test
+  // public void testGetCaseByUprn_mixedCaseTypes() throws Exception {
+  // casesFromRm.get(0).setCaseType("HI"); // Household Individual case
+  // mockCasesFromRm();
+  // CaseDTO result = getCasesByUprn(true);
+  // verifyNonCachedCase(result, true, 1);
+  // }
+
+  // @Test
+  // public void testGetCaseByUprn_caseSPG() throws Exception {
+  // casesFromRm.get(0).setCaseType("SPG");
+  // mockCasesFromRm();
+  // CaseDTO result = getCasesByUprn(true);
+  // verifyNonCachedCase(result, true, 0);
+  // }
+
+  // @Test
+  // public void testGetCaseByUprn_caseHH() throws Exception {
+  // casesFromRm.get(0).setCaseType("HH");
+  // mockCasesFromRm();
+  // CaseDTO result = getCasesByUprn(true);
+  // verifyNonCachedCase(result, true, 0);
+  // }
+  //
+  // @Test
+  // public void shouldGetSecureEstablishmentByUprn() throws Exception {
+  // setLastUpdated(casesFromRm.get(0), 2020, 5, 14);
+  // setLastUpdated(casesFromRm.get(1), 2020, 5, 15);
+  // mockCasesFromRm();
+  // CaseDTO result = getCasesByUprn(false);
+  // assertTrue(result.isSecureEstablishment());
+  // assertEquals(new UniquePropertyReferenceNumber(AN_ESTAB_UPRN), result.getEstabUprn());
+  // }
+  //
+  // // --- results from both RM and cache ...
+  //
+  // @Test
+  // public void shouldGetLatestFromCacheWhenResultsFromBothRmAndCache() throws Exception {
+  // mockCasesFromRm();
+  // mockCasesFromCache();
+  // CaseDTO result = getCasesByUprn(false);
+  // assertEquals(CACHED_CASE_ID_1, result.getId());
+  // }
+
+  // @Test
+  // public void shouldGetLatestFromCacheWhenResultsFromBothRmAndCacheWithSmallTimeDifference()
+  // throws Exception {
+  // casesFromCache.get(0).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 2, 3, 10, 4, 6)));
+  // casesFromCache.get(1).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 2, 3, 10, 4, 5)));
+  // casesFromRm.get(0).setLastUpdated(utcDate(LocalDateTime.of(2020, 1, 4, 0, 0)));
+  // casesFromRm.get(1).setLastUpdated(utcDate(LocalDateTime.of(2019, 12, 12, 0, 0)));
+  // mockCasesFromRm();
+  // mockCasesFromCache();
+  // CaseDTO result = getCasesByUprn(false);
+  // assertEquals(CACHED_CASE_ID_0, result.getId());
+  // }
+  //
+  // @Test
+  // public void shouldGetLatestFromRmWhenResultsFromBothRmAndCache() throws Exception {
+  // casesFromCache.get(0).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 1, 2, 0, 0)));
+  // casesFromCache.get(1).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 1, 3, 0, 0)));
+  // casesFromRm.get(0).setLastUpdated(utcDate(LocalDateTime.of(2020, 1, 1, 0, 0)));
+  // casesFromRm.get(1).setLastUpdated(utcDate(LocalDateTime.of(2020, 1, 23, 0, 0)));
+  // mockCasesFromRm();
+  // mockCasesFromCache();
+  // CaseDTO result = getCasesByUprn(false);
+  // assertEquals(UUID_1, result.getId());
+  // }
+  //
+  // @Test
+  // public void shouldGetLatestFromRmWhenResultsFromBothRmAndCacheWithSmallTimeDifferences()
+  // throws Exception {
+  // casesFromCache.get(0).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 1, 3, 0, 0)));
+  // casesFromCache.get(1).setCreatedDateTime(utcDate(LocalDateTime.of(2020, 2, 3, 10, 4, 5)));
+  // casesFromRm.get(0).setLastUpdated(utcDate(LocalDateTime.of(2020, 1, 1, 0, 0)));
+  // casesFromRm.get(1).setLastUpdated(utcDate(LocalDateTime.of(2020, 2, 3, 10, 4, 6)));
+  // mockCasesFromRm();
+  // mockCasesFromCache();
+  // CaseDTO result = getCasesByUprn(false);
+  // assertEquals(UUID_1, result.getId());
+  // }
+
+  // ---- helpers methods below ---
+
+  // private void mockCasesFromRm() {
+  // when(caseServiceClient.getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET))).thenReturn(casesFromRm);
+  // }
+
+  private void mockNothingInRm() {
+    doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
+        .when(caseServiceClient)
+        .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));
+  }
+
+  private void verifyCallToGetCasesFromRm() {
+    verify(caseServiceClient).getCaseByUprn(any(Long.class), any(Boolean.class));
+  }
+
+  //  private void verifyHasReadCachedCases() throws Exception {
+  //    verify(dataRepo).readCachedCasesByUprn(any(UniquePropertyReferenceNumber.class));
+  //  }
+  //
+  //  private CachedCase verifyHasWrittenCachedCase() throws Exception {
+  //    ArgumentCaptor<CachedCase> cachedCaseCaptor = ArgumentCaptor.forClass(CachedCase.class);
+  //    verify(dataRepo).writeCachedCase(cachedCaseCaptor.capture());
+  //    return cachedCaseCaptor.getValue();
+  //  }
+  //
+  //  // private void mockAddressFromAI() throws Exception {
+  //  // when(addressSvc.uprnQuery(UPRN.getValue())).thenReturn(addressFromAI);
+  //  // }
+  //
+  //  private void verifyNonCachedCase(CaseDTO results, boolean caseEventsExpected, int dataIndex)
+  //      throws Exception {
+  //    CaseDTO expectedCaseResult =
+  //        createExpectedCaseDTO(casesFromRm.get(dataIndex), caseEventsExpected);
+  //
+  //    verifyCase(results, expectedCaseResult, caseEventsExpected);
+  //    verifyHasReadCachedCases();
+  //  }
+
+  // private void verifyNewCase(CaseDTO result) throws Exception {
+  //
+  // verifyCallToGetCasesFromRm();
+  // verifyHasReadCachedCases();
+  // verify(addressSvc, times(1)).uprnQuery(anyLong());
+  //
+  // // Verify content of case written to Firestore
+  // CachedCase capturedCase = verifyHasWrittenCachedCase();
+  // verifyCachedCaseContent(result.getId(), CaseType.HH, capturedCase);
+  //
+  // // Verify response
+  // CachedCase cachedCase = mapperFacade.map(addressFromAI, CachedCase.class);
+  // cachedCase.setId(result.getId().toString());
+  // verifyCaseDTOContent(cachedCase, CaseType.HH.name(), false, result);
+  //
+  // // Verify the NewAddressEvent
+  // CollectionCaseNewAddress newAddress =
+  // mapperFacade.map(addressFromAI, CollectionCaseNewAddress.class);
+  // newAddress.setId(cachedCase.getId());
+  // verifyNewAddressEventSent(addressFromAI.getCensusAddressType(),
+  // addressFromAI.getCensusEstabType(), newAddress);
+  // }
+
+  // private void verifyCachedCaseContent(UUID expectedId, CaseType expectedCaseType,
+  // CachedCase expectedCase) {
+  // assertEquals(expectedId.toString(), expectedCase.getId());
+  // assertEquals(addressFromAI.getUprn(), expectedCase.getUprn());
+  // assertEquals(addressFromAI.getAddressLine1(), expectedCase.getAddressLine1());
+  // assertEquals(addressFromAI.getAddressLine2(), expectedCase.getAddressLine2());
+  // assertEquals(addressFromAI.getAddressLine3(), expectedCase.getAddressLine3());
+  // assertEquals(addressFromAI.getTownName(), expectedCase.getTownName());
+  // assertEquals(addressFromAI.getPostcode(), expectedCase.getPostcode());
+  // assertEquals(addressFromAI.getCensusAddressType(), expectedCase.getAddressType());
+  // assertEquals(expectedCaseType, expectedCase.getCaseType());
+  // assertEquals(addressFromAI.getCensusEstabType(), expectedCase.getEstabType());
+  // assertEquals(addressFromAI.getCountryCode(), expectedCase.getRegion());
+  // assertEquals(addressFromAI.getOrganisationName(), expectedCase.getCeOrgName());
+  // assertEquals(0, expectedCase.getCaseEvents().size());
+  // }
+
+  //  private void verifyCaseDTOContent(CachedCase cachedCase, String expectedCaseType,
+  //      boolean isSecureEstablishment, CaseDTO actualCaseDto) {
+  //    CaseDTO expectedNewCaseResult = mapperFacade.map(cachedCase, CaseDTO.class);
+  //    expectedNewCaseResult.setCreatedDateTime(actualCaseDto.getCreatedDateTime());
+  //    expectedNewCaseResult.setCaseType(expectedCaseType);
+  //    expectedNewCaseResult.setEstabType(EstabType.forCode(cachedCase.getEstabType()));
+  //    expectedNewCaseResult.setSecureEstablishment(isSecureEstablishment);
+  //    expectedNewCaseResult.setAllowedDeliveryChannels(Arrays.asList(DeliveryChannel.values()));
+  //    expectedNewCaseResult.setCaseEvents(Collections.emptyList());
+  //    assertEquals(expectedNewCaseResult, actualCaseDto);
+  //  }
+
+  // private CaseDTO getCasesByUprn(boolean caseEvents) throws CTPException {
+  // List<CaseDTO> results = target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(caseEvents));
+  // assertEquals(1, results.size());
+  // return results.get(0);
+  // }
+
+  private CaseDTO getCasesByPostcode(String postcode) throws CTPException {
+    List<CaseDTO> results = target.getCCSCaseByPostcode(postcode);
+    assertEquals(2, results.size());
+    return results.get(0);
+  }
+}

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
@@ -44,7 +44,7 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
 
   @Test(expected = ResponseStatusException.class)
   public void testGetCcsCaseByPostcode_caseSvcRestClientException() throws Exception {
-
+    when(ccsPostcodesBean.isInCCSPostcodes(POSTCODE_IN_CCS_SET)).thenReturn(true);
     doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT))
         .when(caseServiceClient)
         .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));
@@ -56,12 +56,14 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
   public void testGetCcsCaseByPostcode_withPostcodeInRMAndInCCSPostcodes() throws CTPException {
     casesFromRm.get(1).setPostcode(POSTCODE_IN_CCS_SET);
     when(caseServiceClient.getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET))).thenReturn(casesFromRm);
+    when(ccsPostcodesBean.isInCCSPostcodes(POSTCODE_IN_CCS_SET)).thenReturn(true);
     CaseDTO result = getCasesByPostcode(POSTCODE_IN_CCS_SET);
     assertEquals(CASE_ID, result.getId());
   }
 
   @Test
   public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndInCCSPostcodes() throws CTPException {
+    when(ccsPostcodesBean.isInCCSPostcodes(POSTCODE_IN_CCS_SET)).thenReturn(true);
     doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
         .when(caseServiceClient)
         .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
@@ -50,22 +50,18 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
   @Before
   public void setup() {
     mockCcsPostcodes();
-
-    // when(appConfig.getChannel()).thenReturn(Channel.CC);
-    // when(appConfig.getSurveyName()).thenReturn(SURVEY_NAME);
-    // when(appConfig.getCollectionExerciseId()).thenReturn(COLLECTION_EXERCISE_ID);
-
     casesFromRm = FixtureHelper.loadPackageFixtures(CaseContainerDTO[].class);
   }
 
-  //  @Test(expected = ResponseStatusException.class)
-  //  public void testGetCcsCaseByPostcode_caseSvcRestClientException() throws Exception {
-  //
-  //    doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT)).when(caseServiceClient)
-  //        .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));
-  //
-  //    target.getCCSCaseByPostcode(POSTCODE_IN_CCS_SET);
-  //  }
+  @Test(expected = ResponseStatusException.class)
+  public void testGetCcsCaseByPostcode_caseSvcRestClientException() throws Exception {
+
+    doThrow(new ResponseStatusException(HttpStatus.I_AM_A_TEAPOT))
+        .when(caseServiceClient)
+        .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));
+
+    target.getCCSCaseByPostcode(POSTCODE_IN_CCS_SET);
+  }
 
   @Test
   public void testGetCcsCaseByPostcode_withPostcodeInRMAndInCCSPostcodes() throws CTPException {
@@ -78,30 +74,40 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
 
   @Test
   public void testGetCcsCaseByPostcode_withPostcodeInRMAndNotInCCSPostcodes() throws CTPException {
-    casesFromRm.get(1).setPostcode(POSTCODE_NOT_IN_CCS_SET);
-    // mockCasesFromRm();
-    //
-    // when(caseServiceClient.getCcsCaseByPostcode(eq(POSTCODE_NOT_IN_CCS_SET))).thenReturn(casesFromRm);
-    //    ResponseStatusException ex = new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
-    //        "Bad Request", new HttpClientErrorException(HttpStatus.BAD_REQUEST));
-    //    Mockito.doThrow(ex).when(caseServiceClient.getCcsCaseByPostcode(POSTCODE_NOT_IN_CCS_SET));
+    // casesFromRm.get(1).setPostcode(POSTCODE_NOT_IN_CCS_SET);
     try {
-      CaseDTO result = getCasesByPostcode(POSTCODE_NOT_IN_CCS_SET);
+      getCasesByPostcode(POSTCODE_NOT_IN_CCS_SET);
       fail();
     } catch (CTPException badRequest) {
       assertEquals(Fault.BAD_REQUEST, badRequest.getFault());
     }
   }
 
-  //  @Test
-  //  public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndInCCSPostcodes() {
+  @Test
+  public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndInCCSPostcodes() throws CTPException {
+    //    casesFromRm.get(1).setPostcode(POSTCODE_IN_CCS_SET);
+    // mockCasesFromRm();
+    //
+    // when(caseServiceClient.getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET))).thenReturn(casesFromRm);
+    //    ResponseStatusException ex = new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR,
+    //        "Resource Not Found", new HttpClientErrorException(HttpStatus.NOT_FOUND));
+    //    Mockito.doThrow(ex).when(caseServiceClient.getCcsCaseByPostcode(POSTCODE_IN_CCS_SET));
+    doThrow(new ResponseStatusException(HttpStatus.NOT_FOUND))
+        .when(caseServiceClient)
+        .getCcsCaseByPostcode(eq(POSTCODE_IN_CCS_SET));
+    try {
+      getCasesByPostcode(POSTCODE_IN_CCS_SET);
+      fail();
+    } catch (ResponseStatusException notFound) {
+      //      assertTrue(notFound.getMessage().contains(Fault.RESOURCE_NOT_FOUND.toString()));
+      assertEquals(HttpStatus.NOT_FOUND, notFound.getStatus());
+    }
+  }
   //
-  //  }
+  // @Test
+  // public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndNotInCCSPostcodes() {
   //
-  //  @Test
-  //  public void testGetCcsCaseByPostcode_withPostcodeNotInRMAndNotInCCSPostcodes() {
-  //
-  //  }
+  // }
 
   // @Test
   // public void testGetCaseByUprn_withCaseDetailsForCaseTypeHH() throws Exception {
@@ -348,28 +354,28 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
     verify(caseServiceClient).getCaseByUprn(any(Long.class), any(Boolean.class));
   }
 
-  //  private void verifyHasReadCachedCases() throws Exception {
-  //    verify(dataRepo).readCachedCasesByUprn(any(UniquePropertyReferenceNumber.class));
-  //  }
+  // private void verifyHasReadCachedCases() throws Exception {
+  // verify(dataRepo).readCachedCasesByUprn(any(UniquePropertyReferenceNumber.class));
+  // }
   //
-  //  private CachedCase verifyHasWrittenCachedCase() throws Exception {
-  //    ArgumentCaptor<CachedCase> cachedCaseCaptor = ArgumentCaptor.forClass(CachedCase.class);
-  //    verify(dataRepo).writeCachedCase(cachedCaseCaptor.capture());
-  //    return cachedCaseCaptor.getValue();
-  //  }
+  // private CachedCase verifyHasWrittenCachedCase() throws Exception {
+  // ArgumentCaptor<CachedCase> cachedCaseCaptor = ArgumentCaptor.forClass(CachedCase.class);
+  // verify(dataRepo).writeCachedCase(cachedCaseCaptor.capture());
+  // return cachedCaseCaptor.getValue();
+  // }
   //
-  //  // private void mockAddressFromAI() throws Exception {
-  //  // when(addressSvc.uprnQuery(UPRN.getValue())).thenReturn(addressFromAI);
-  //  // }
+  // // private void mockAddressFromAI() throws Exception {
+  // // when(addressSvc.uprnQuery(UPRN.getValue())).thenReturn(addressFromAI);
+  // // }
   //
-  //  private void verifyNonCachedCase(CaseDTO results, boolean caseEventsExpected, int dataIndex)
-  //      throws Exception {
-  //    CaseDTO expectedCaseResult =
-  //        createExpectedCaseDTO(casesFromRm.get(dataIndex), caseEventsExpected);
+  // private void verifyNonCachedCase(CaseDTO results, boolean caseEventsExpected, int dataIndex)
+  // throws Exception {
+  // CaseDTO expectedCaseResult =
+  // createExpectedCaseDTO(casesFromRm.get(dataIndex), caseEventsExpected);
   //
-  //    verifyCase(results, expectedCaseResult, caseEventsExpected);
-  //    verifyHasReadCachedCases();
-  //  }
+  // verifyCase(results, expectedCaseResult, caseEventsExpected);
+  // verifyHasReadCachedCases();
+  // }
 
   // private void verifyNewCase(CaseDTO result) throws Exception {
   //
@@ -411,17 +417,17 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
   // assertEquals(0, expectedCase.getCaseEvents().size());
   // }
 
-  //  private void verifyCaseDTOContent(CachedCase cachedCase, String expectedCaseType,
-  //      boolean isSecureEstablishment, CaseDTO actualCaseDto) {
-  //    CaseDTO expectedNewCaseResult = mapperFacade.map(cachedCase, CaseDTO.class);
-  //    expectedNewCaseResult.setCreatedDateTime(actualCaseDto.getCreatedDateTime());
-  //    expectedNewCaseResult.setCaseType(expectedCaseType);
-  //    expectedNewCaseResult.setEstabType(EstabType.forCode(cachedCase.getEstabType()));
-  //    expectedNewCaseResult.setSecureEstablishment(isSecureEstablishment);
-  //    expectedNewCaseResult.setAllowedDeliveryChannels(Arrays.asList(DeliveryChannel.values()));
-  //    expectedNewCaseResult.setCaseEvents(Collections.emptyList());
-  //    assertEquals(expectedNewCaseResult, actualCaseDto);
-  //  }
+  // private void verifyCaseDTOContent(CachedCase cachedCase, String expectedCaseType,
+  // boolean isSecureEstablishment, CaseDTO actualCaseDto) {
+  // CaseDTO expectedNewCaseResult = mapperFacade.map(cachedCase, CaseDTO.class);
+  // expectedNewCaseResult.setCreatedDateTime(actualCaseDto.getCreatedDateTime());
+  // expectedNewCaseResult.setCaseType(expectedCaseType);
+  // expectedNewCaseResult.setEstabType(EstabType.forCode(cachedCase.getEstabType()));
+  // expectedNewCaseResult.setSecureEstablishment(isSecureEstablishment);
+  // expectedNewCaseResult.setAllowedDeliveryChannels(Arrays.asList(DeliveryChannel.values()));
+  // expectedNewCaseResult.setCaseEvents(Collections.emptyList());
+  // assertEquals(expectedNewCaseResult, actualCaseDto);
+  // }
 
   // private CaseDTO getCasesByUprn(boolean caseEvents) throws CTPException {
   // List<CaseDTO> results = target.getCaseByUPRN(UPRN, new CaseQueryRequestDTO(caseEvents));
@@ -431,7 +437,7 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
 
   private CaseDTO getCasesByPostcode(String postcode) throws CTPException {
     List<CaseDTO> results = target.getCCSCaseByPostcode(postcode);
-    assertEquals(2, results.size());
+    // assertEquals(2, results.size());
     return results.get(0);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCcsCaseByPostcodeTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import org.junit.Before;
@@ -36,7 +37,7 @@ public class CaseServiceImplGetCcsCaseByPostcodeTest extends CaseServiceImplTest
   List<CaseContainerDTO> casesFromRm;
 
   @Before
-  public void setup() {
+  public void setup() throws IOException {
     mockCcsPostcodes();
     casesFromRm = FixtureHelper.loadPackageFixtures(CaseContainerDTO[].class);
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -28,6 +28,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.EstabType;
@@ -43,6 +44,7 @@ import uk.gov.ons.ctp.common.time.DateTimeUtil;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.CaseServiceClientServiceImpl;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
 import uk.gov.ons.ctp.integration.common.product.ProductReference;
+import uk.gov.ons.ctp.integration.contactcentresvc.CCSPostcodesBean;
 import uk.gov.ons.ctp.integration.contactcentresvc.CCSvcBeanMapper;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.AppConfig;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.CCSPostcodes;
@@ -73,6 +75,8 @@ public abstract class CaseServiceImplTestBase {
   @Mock CaseDataRepository dataRepo;
 
   @Mock AddressService addressSvc;
+  
+  @Mock CCSPostcodesBean ccsPostcodesBean;
 
   static final List<DeliveryChannel> ALL_DELIVERY_CHANNELS =
       List.of(DeliveryChannel.POST, DeliveryChannel.SMS);
@@ -205,7 +209,6 @@ public abstract class CaseServiceImplTestBase {
     Set<String> ccsPostcodesSet = Set.of("GW12 AAA", "GW12 AAB", "HP22 4HU");
     ccsPostcodes.setCcsDefaultPostcodes(ccsPostcodesSet);
     ccsPostcodes.setCcsPostcodePath("/etc/config/ccs-postcodes");
-    when(appConfig.getCcsPostcodes()).thenReturn(ccsPostcodes);
   }
 
   void assertCaseQIDRestClientFailureCaught(Exception ex, boolean caught) {

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -74,6 +74,8 @@ public abstract class CaseServiceImplTestBase {
 
   @Mock AddressService addressSvc;
 
+  @Mock CCSPostcodes ccsPostcodes = new CCSPostcodes();
+
   static final List<DeliveryChannel> ALL_DELIVERY_CHANNELS =
       List.of(DeliveryChannel.POST, DeliveryChannel.SMS);
 
@@ -202,7 +204,7 @@ public abstract class CaseServiceImplTestBase {
 
   void mockCcsPostcodes() throws IOException {
     CCSPostcodes ccsPostcodes = new CCSPostcodes();
-    Set<String> ccsPostcodesSet = Set.of("GW12AAA", "GW12AAB", "HP224HU");
+    Set<String> ccsPostcodesSet = Set.of("GW12 AAA", "GW12 AAB", "HP22 4HU");
     ccsPostcodes.setCcsPostcodesToCheck(ccsPostcodesSet);
     when(appConfig.getCcsPostcodes()).thenReturn(ccsPostcodes);
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -44,6 +44,7 @@ import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerD
 import uk.gov.ons.ctp.integration.common.product.ProductReference;
 import uk.gov.ons.ctp.integration.contactcentresvc.CCSvcBeanMapper;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.AppConfig;
+import uk.gov.ons.ctp.integration.contactcentresvc.config.CCSPostcodes;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.CaseServiceSettings;
 import uk.gov.ons.ctp.integration.contactcentresvc.repository.CaseDataRepository;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.CaseDTO;
@@ -196,6 +197,13 @@ public abstract class CaseServiceImplTestBase {
     Set<String> whitelistedSet = Set.of("CASE_CREATED", "CASE_UPDATED");
     caseServiceSettings.setWhitelistedEventCategories(whitelistedSet);
     when(appConfig.getCaseServiceSettings()).thenReturn(caseServiceSettings);
+  }
+
+  void mockCcsPostcodes() {
+    CCSPostcodes ccsPostcodes = new CCSPostcodes();
+    Set<String> ccsPostcodesSet = Set.of("GW12AAA", "GW12AAB", "HP224HU");
+    ccsPostcodes.setCcsPostcodesToCheck(ccsPostcodesSet);
+    when(appConfig.getCcsPostcodes()).thenReturn(ccsPostcodes);
   }
 
   void assertCaseQIDRestClientFailureCaught(Exception ex, boolean caught) {

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -28,7 +28,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.Spy;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.EstabType;
@@ -75,7 +74,7 @@ public abstract class CaseServiceImplTestBase {
   @Mock CaseDataRepository dataRepo;
 
   @Mock AddressService addressSvc;
-  
+
   @Mock CCSPostcodesBean ccsPostcodesBean;
 
   static final List<DeliveryChannel> ALL_DELIVERY_CHANNELS =

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -74,8 +74,6 @@ public abstract class CaseServiceImplTestBase {
 
   @Mock AddressService addressSvc;
 
-  @Mock CCSPostcodes ccsPostcodes;
-
   static final List<DeliveryChannel> ALL_DELIVERY_CHANNELS =
       List.of(DeliveryChannel.POST, DeliveryChannel.SMS);
 
@@ -205,7 +203,7 @@ public abstract class CaseServiceImplTestBase {
   void mockCcsPostcodes() throws IOException {
     CCSPostcodes ccsPostcodes = new CCSPostcodes();
     Set<String> ccsPostcodesSet = Set.of("GW12 AAA", "GW12 AAB", "HP22 4HU");
-    ccsPostcodes.setCcsPostcodesToCheck(ccsPostcodesSet);
+    ccsPostcodes.setCcsDefaultPostcodes(ccsPostcodesSet);
     ccsPostcodes.setCcsPostcodePath("/etc/config/ccs-postcodes");
     when(appConfig.getCcsPostcodes()).thenReturn(ccsPostcodes);
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -74,7 +74,7 @@ public abstract class CaseServiceImplTestBase {
 
   @Mock AddressService addressSvc;
 
-  @Mock CCSPostcodes ccsPostcodes = new CCSPostcodes();
+  @Mock CCSPostcodes ccsPostcodes;
 
   static final List<DeliveryChannel> ALL_DELIVERY_CHANNELS =
       List.of(DeliveryChannel.POST, DeliveryChannel.SMS);
@@ -206,6 +206,7 @@ public abstract class CaseServiceImplTestBase {
     CCSPostcodes ccsPostcodes = new CCSPostcodes();
     Set<String> ccsPostcodesSet = Set.of("GW12 AAA", "GW12 AAB", "HP22 4HU");
     ccsPostcodes.setCcsPostcodesToCheck(ccsPostcodesSet);
+    ccsPostcodes.setCcsPostcodePath("/etc/config/ccs-postcodes");
     when(appConfig.getCcsPostcodes()).thenReturn(ccsPostcodes);
   }
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplTestBase.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.when;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.AN_AGENT_ID;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.UUID_0;
 
+import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
@@ -199,7 +200,7 @@ public abstract class CaseServiceImplTestBase {
     when(appConfig.getCaseServiceSettings()).thenReturn(caseServiceSettings);
   }
 
-  void mockCcsPostcodes() {
+  void mockCcsPostcodes() throws IOException {
     CCSPostcodes ccsPostcodes = new CCSPostcodes();
     Set<String> ccsPostcodesSet = Set.of("GW12AAA", "GW12AAB", "HP224HU");
     ccsPostcodes.setCcsPostcodesToCheck(ccsPostcodesSet);


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The CR-744 task is to create a new endpoint, in the contact centre sevice, which will allow Serco staff to search for a CCS (Census Coverage Survey) case by postcode.

Serco will not be able to find the CCS cases that RM creates using the usual UPRN endpoint; RM have implemented a new endpoint in the Case API service:

@GetMapping(value = "/ccs/postcode/{postcode}")
  public List<CaseContainerDTO> findCCSCasesByPostcode(
      @PathVariable("postcode") String postcode,
      @RequestParam(value = "caseEvents", required = false, defaultValue = "false")
          boolean caseEvents);

The new contact centre service endpoint is slightly different to the existing GET case endpoints in the CC:

- This endpoint does NOT create a cached case - it cannot as it does not have the details required
- This endpoint first checks for the existence of the requested postcode in a list of CCS postcodes and, if the postcode does not exist in that list, it responds with BAD_REQUEST.

The three possible responses from the new endpoint are:

- BAD_REQUEST : postcode not in the cached list with the message ""The requested postcode is not within the CCS sample""
- SUCCESS: RM found the CC Case by postcode
- NOT_FOUND : RM did not find the case

# What has changed
<!--- What code changes has been made -->
The new endpoint has been created and is named getCCSCaseByPostcode

The method signature is:

@RequestMapping(value = "/ccs/postcode/{postcode}", method = RequestMethod.GET)
  @ResponseStatus(value = HttpStatus.OK)
  public ResponseEntity<List<CaseDTO>> getCCSCaseByPostcode(
      @PathVariable(value = "postcode") @NotBlank @Pattern(regexp = Constants.POSTCODE_RE)
          final String postcode)
      throws CTPException

The endpoint validates the postcode of the request against a list of CCS postcodes, which it attempts to read in. The application yml contains the path of the postcodes file. 

The application yml also contains a list of default postcodes, which get used if the external list of postcodes is not read in successfully. However, if that happens then a warning is logged.

Seven JUnit tests have also been written for the new functionality. These are named as follows:
1. getCcsCaseByPostcode_PostcodeInList()
2. getCcsCaseByPostcode_PostcodeInListButNotInRM()
3. getCcsCaseByPostcode_PostcodeNotInList()
4. testGetCcsCaseByPostcode_caseSvcRestClientException()
5. testGetCcsCaseByPostcode_withPostcodeInRMAndInCCSPostcodes()
6. testGetCcsCaseByPostcode_withPostcodeNotInRMAndInCCSPostcodes()
7. testGetCcsCaseByPostcode_withPostcodeNotInCCSPostcodes()     

# How to test?
<!--- Describe in detail how you tested your changes. -->
Run the following command to make sure that you have permission to access Firestore: gcloud auth application-default login
Run the mock case service locally (either using eclipse or mvn spring-boot:run)
Run this branch of the contact centre service.

Use Postman to send a POST request to the following URL:
http://localhost:8161/cases/data/ccs/cases/save

NB. You will need to use basic authentication with the username and password from the mock case service. The request body should be something like this:
    [{
        "caseRef": "123123002",
        "estabType": "ET",
        "uprn": "1347459999",
        "createdDateTime": "2019-04-14T13:45:26.564+01:00",
        "addressLine1": "Happy House",
        "addressLine2": "89 Harbour Street",
        "addressLine3": "Somewhere",
        "townName": "Portsmouth",
        "postcode": "GW12 AAA",
        "organisationName": "ON",
        "addressLevel": "E",
        "abpCode": "AACC",
        "latitude": "41.40338",
        "longitude": "2.17403",
        "oa": "EE22",
        "lsoa": "x1",
        "msoa": "x2",
        "lad": "H1",
        "caseEvents": [
            {
                "id": "101",
                "eventType": "CASE_UPDATED",
                "description": "Initial creation of case",
                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
            },
            {
                "id": "102",
                "eventType": null,
                "description": "Create Household Visit",
                "createdDateTime": "2019-04-14T13:45:26.564+01:00"
            }
        ],
        "id": "3305e937-6fb1-4ce1-9d4c-077f147789aa",
        "caseType": "HH",
        "addressType": "SPG",
        "region": "E",
        "collectionExerciseId": "49871667-117d-4a63-9101-f6a0660f73f6",
        "surveyType": "CENSUS",
        "handDelivery": false
    }]

You can now use the cc svc endpoint to check that you get back the three expected responses, as follows:

1. This URL should give a successful outcome, which is to say that it should return the above case that you've added to the mock case service:

http://localhost:8171/cases/ccs/postcode/GW12 AAA

2. This URL should give a not found message:

http://localhost:8171/cases/ccs/postcode/GW12 AAB

3. This URL should give a bad request message with the text "The requested postcode is not within the CCS sample":

http://localhost:8171/cases/ccs/postcode/GW12 AAC
