### PR TITLE
CR-1191 pom changed to refer latest version of Product Reference Library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>product-reference</artifactId>
-      <version>1.0.10-SNAPSHOT</version>
+      <version>1.0.10</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -135,7 +135,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>product-reference</artifactId>
-      <version>1.0.9</version>
+      <version>1.0.10-SNAPSHOT</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
# Motivation and Context
To use latest version of Product Reference Library
# What has changed
Updated POM to use latest version of Product Reference library.


# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1191
