### PR TITLE
CR-1205 Changed for new EQ launcher version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>eq-launcher</artifactId>
-      <version>0.0.29-SNAPSHOT</version>
+      <version>0.0.30</version>
     </dependency>
 
     <!-- ONS END -->

--- a/pom.xml
+++ b/pom.xml
@@ -147,7 +147,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration.common</groupId>
       <artifactId>eq-launcher</artifactId>
-      <version>0.0.27</version>
+      <version>0.0.29-SNAPSHOT</version>
     </dependency>
 
     <!-- ONS END -->

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AppConfig.java
@@ -26,6 +26,7 @@ public class AppConfig {
   private Resource publicPgpKey1;
   private Resource publicPgpKey2;
   private CCSPostcodes ccsPostcodes;
+  private String passPhrase;
 
   public void setChannel(Channel channel) {
     if (channel.equals(Channel.CC) || channel.equals(Channel.AD)) {

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AppConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/AppConfig.java
@@ -26,7 +26,6 @@ public class AppConfig {
   private Resource publicPgpKey1;
   private Resource publicPgpKey2;
   private CCSPostcodes ccsPostcodes;
-  private String passPhrase;
 
   public void setChannel(Channel channel) {
     if (channel.equals(Channel.CC) || channel.equals(Channel.AD)) {

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/EqConfig.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/config/EqConfig.java
@@ -8,4 +8,5 @@ public class EqConfig {
   @NotBlank private String protocol;
   @NotBlank private String host;
   @NotBlank private String path;
+  @NotBlank private String responseIdSalt;
 }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -82,6 +82,7 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.UACResponseDTO
 import uk.gov.ons.ctp.integration.contactcentresvc.service.AddressService;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 import uk.gov.ons.ctp.integration.contactcentresvc.util.PgpEncrypt;
+import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchData;
 import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchService;
 
 @Service
@@ -1183,19 +1184,22 @@ public class CaseServiceImpl implements CaseService {
       throws CTPException {
     String encryptedPayload = "";
     try {
-      encryptedPayload =
-          eqLaunchService.getEqLaunchJwe(
-              Language.ENGLISH,
-              uk.gov.ons.ctp.common.domain.Source.CONTACT_CENTRE_API,
-              uk.gov.ons.ctp.common.domain.Channel.CC,
-              caseDetails,
-              Integer.toString(requestParamsDTO.getAgentId()),
-              questionnaireId,
-              formType,
-              null,
-              null,
-              appConfig.getKeystore(),
-              appConfig.getPassPhrase());
+      EqLaunchData eqLuanchCoreDate =
+          EqLaunchData.builder()
+              .language(Language.ENGLISH)
+              .source(uk.gov.ons.ctp.common.domain.Source.CONTACT_CENTRE_API)
+              .channel(uk.gov.ons.ctp.common.domain.Channel.CC)
+              .questionnaireId(questionnaireId)
+              .formType(formType)
+              .keyStore(appConfig.getKeystore())
+              .salt(appConfig.getEq().getResponseIdSalt())
+              .caseContainer(caseDetails)
+              .userId(Integer.toString(requestParamsDTO.getAgentId()))
+              .accountServiceUrl(null)
+              .accountServiceLogoutUrl(null)
+              .build();
+      encryptedPayload = eqLaunchService.getEqLaunchJwe(eqLuanchCoreDate);
+
     } catch (CTPException e) {
       log.with(e).error("Failed to create JWE payload for eq launch");
       throw e;

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1194,7 +1194,8 @@ public class CaseServiceImpl implements CaseService {
               formType,
               null,
               null,
-              appConfig.getKeystore());
+              appConfig.getKeystore(),
+              appConfig.getPassPhrase());
     } catch (CTPException e) {
       log.with(e).error("Failed to create JWE payload for eq launch");
       throw e;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,8 +17,6 @@ logging:
   profile: DEV
   useJson: true
 
-# This passphrase is used to encrypt the responseId in EQ, (passed as SALT to EQ)
-passPhrase: CENSUS
 surveyName: CENSUS
 collectionExerciseId : 34d7f3bb-91c9-45d0-bb2d-90afce4fc790
 public-pgp-key-1 : classpath:pgp/key1.asc
@@ -143,6 +141,7 @@ eq:
   protocol: https
   host: www.google.com
   path: /en/start/launch-eq/?token=
+  response-id-salt: CENSUS
   
 report-settings:
   cron-expression: "0 * * * * *"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,6 +17,8 @@ logging:
   profile: DEV
   useJson: true
 
+# This passphrase is used to encrypt the responseId in EQ, (passed as SALT to EQ)
+passPhrase: CENSUS
 surveyName: CENSUS
 collectionExerciseId : 34d7f3bb-91c9-45d0-bb2d-90afce4fc790
 public-pgp-key-1 : classpath:pgp/key1.asc

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
@@ -30,6 +30,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.FormType;
+import uk.gov.ons.ctp.common.domain.Language;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
@@ -204,10 +205,20 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
         "All Northern Ireland calls from CE Managers are to be escalated to the NI management team.");
   }
 
-  private void verifyEqLaunchJwe(boolean individual, String caseType) throws Exception {
+  private void verifyEqLaunchJwe(
+      String questionnaireId, boolean individual, String caseType, FormType formType)
+      throws Exception {
     Mockito.verify(eqLaunchService).getEqLaunchJwe(eqLaunchDataCaptor.capture());
-
     EqLaunchData eqLaunchData = eqLaunchDataCaptor.getValue();
+
+    assertEquals(Language.ENGLISH, eqLaunchData.getLanguage());
+    assertEquals(uk.gov.ons.ctp.common.domain.Source.CONTACT_CENTRE_API, eqLaunchData.getSource());
+    assertEquals(uk.gov.ons.ctp.common.domain.Channel.CC, eqLaunchData.getChannel());
+    assertEquals(AN_AGENT_ID, eqLaunchData.getUserId());
+    assertEquals(questionnaireId, eqLaunchData.getQuestionnaireId());
+    assertEquals(formType.name(), eqLaunchData.getFormType());
+    assertNull(eqLaunchData.getAccountServiceLogoutUrl());
+    assertNull(eqLaunchData.getAccountServiceUrl());
     if (caseType.equals("HH") && individual) {
       // Should have used a new caseId, ie, not the uuid that we started with
       assertNotEquals(UUID_0, eqLaunchData.getCaseContainer().getId());
@@ -279,7 +290,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
         launchUrl);
 
     verifyCorrectIndividualCaseId(caseType, individual);
-    verifyEqLaunchJwe(individual, caseType);
+    verifyEqLaunchJwe(A_QUESTIONNAIRE_ID, individual, caseType, formType);
     verifySurveyLaunchedEventPublished(caseType, individual, UUID_0, A_QUESTIONNAIRE_ID);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
@@ -7,7 +7,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.AN_AGENT_ID;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_QUESTIONNAIRE_ID;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_REGION;
@@ -22,6 +22,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
+import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.HttpStatus;
@@ -29,7 +30,6 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.FormType;
-import uk.gov.ons.ctp.common.domain.Language;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.common.error.CTPException.Fault;
 import uk.gov.ons.ctp.common.event.EventPublisher.Channel;
@@ -41,6 +41,8 @@ import uk.gov.ons.ctp.integration.contactcentresvc.cloud.CachedCase;
 import uk.gov.ons.ctp.integration.contactcentresvc.config.EqConfig;
 import uk.gov.ons.ctp.integration.contactcentresvc.representation.LaunchRequestDTO;
 import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
+import uk.gov.ons.ctp.integration.eqlaunch.crypto.KeyStore;
+import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchData;
 
 /**
  * Unit Test {@link CaseService#getLaunchURLForCaseId(UUID, LaunchRequestDTO)
@@ -50,7 +52,8 @@ import uk.gov.ons.ctp.integration.contactcentresvc.service.CaseService;
 public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
 
   @Captor private ArgumentCaptor<UUID> individualCaseIdCaptor;
-  @Captor private ArgumentCaptor<CaseContainerDTO> caseCaptor;
+  @Captor private ArgumentCaptor<EqLaunchData> eqLaunchDataCaptor;
+  @Mock private KeyStore keyStoreEncryption;
 
   @Before
   public void setup() {
@@ -58,10 +61,11 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
     eqConfig.setProtocol("https");
     eqConfig.setHost("localhost");
     eqConfig.setPath("/en/start/launch-eq/?token=");
+    eqConfig.setResponseIdSalt("CENSUS");
     appConfig.setEq(eqConfig);
 
     Mockito.when(appConfig.getChannel()).thenReturn(Channel.CC);
-    Mockito.when(appConfig.getPassPhrase()).thenReturn("CENSUS");
+    Mockito.when(appConfig.getEq()).thenReturn(eqConfig);
   }
 
   @Test
@@ -200,47 +204,15 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
         "All Northern Ireland calls from CE Managers are to be escalated to the NI management team.");
   }
 
-  private void mockEqLaunchJwe() throws Exception {
-    // Mock out building of launch payload
-    Mockito.when(
-            eqLaunchService.getEqLaunchJwe(
-                eq(Language.ENGLISH),
-                eq(uk.gov.ons.ctp.common.domain.Source.CONTACT_CENTRE_API),
-                eq(uk.gov.ons.ctp.common.domain.Channel.CC),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                any(),
-                isNull(),
-                any())) // keystore
-        .thenReturn("simulated-encrypted-payload");
-  }
+  private void verifyEqLaunchJwe(boolean individual, String caseType) throws Exception {
+    Mockito.verify(eqLaunchService).getEqLaunchJwe(eqLaunchDataCaptor.capture());
 
-  private void verifyEqLaunchJwe(
-      String questionnaireId, boolean individual, String caseType, FormType formType)
-      throws Exception {
-    Mockito.verify(eqLaunchService)
-        .getEqLaunchJwe(
-            eq(Language.ENGLISH),
-            eq(uk.gov.ons.ctp.common.domain.Source.CONTACT_CENTRE_API),
-            eq(uk.gov.ons.ctp.common.domain.Channel.CC),
-            caseCaptor.capture(),
-            eq(AN_AGENT_ID), // agent
-            eq(questionnaireId),
-            eq(formType.name()),
-            isNull(), // accountServiceUrl
-            isNull(),
-            any(),
-            any()); // keystore
-
-    CaseContainerDTO capturedCase = caseCaptor.getValue();
+    EqLaunchData eqLaunchData = eqLaunchDataCaptor.getValue();
     if (caseType.equals("HH") && individual) {
       // Should have used a new caseId, ie, not the uuid that we started with
-      assertNotEquals(UUID_0, capturedCase.getId());
+      assertNotEquals(UUID_0, eqLaunchData.getCaseContainer().getId());
     } else {
-      assertEquals(UUID_0, capturedCase.getId());
+      assertEquals(UUID_0, eqLaunchData.getCaseContainer().getId());
     }
   }
 
@@ -270,6 +242,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
   }
 
   private void doLaunchTest(String caseType, boolean individual) throws Exception {
+    when(appConfig.getKeystore()).thenReturn(keyStoreEncryption);
     CaseContainerDTO caseFromCaseService = mockGetCaseById(caseType, "U", A_REGION.name());
     doLaunchTest(individual, caseFromCaseService, FormType.H);
   }
@@ -286,7 +259,9 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
     Mockito.when(caseServiceClient.getSingleUseQuestionnaireId(eq(UUID_0), eq(individual), any()))
         .thenReturn(newQuestionnaireIdDto);
 
-    mockEqLaunchJwe();
+    // Mock out building of launch payload
+    Mockito.when(eqLaunchService.getEqLaunchJwe(any(EqLaunchData.class)))
+        .thenReturn("simulated-encrypted-payload");
 
     List<LaunchRequestDTO> requestsFromCCSvc =
         FixtureHelper.loadClassFixtures(LaunchRequestDTO[].class);
@@ -304,7 +279,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
         launchUrl);
 
     verifyCorrectIndividualCaseId(caseType, individual);
-    verifyEqLaunchJwe(A_QUESTIONNAIRE_ID, individual, caseType, formType);
+    verifyEqLaunchJwe(individual, caseType);
     verifySurveyLaunchedEventPublished(caseType, individual, UUID_0, A_QUESTIONNAIRE_ID);
   }
 }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
@@ -61,6 +61,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
     appConfig.setEq(eqConfig);
 
     Mockito.when(appConfig.getChannel()).thenReturn(Channel.CC);
+    Mockito.when(appConfig.getPassPhrase()).thenReturn("CENSUS");
   }
 
   @Test
@@ -212,7 +213,8 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
                 any(),
                 any(),
                 any(),
-                isNull())) // keystore
+                isNull(),
+                any())) // keystore
         .thenReturn("simulated-encrypted-payload");
   }
 
@@ -230,6 +232,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
             eq(formType.name()),
             isNull(), // accountServiceUrl
             isNull(),
+            any(),
             any()); // keystore
 
     CaseContainerDTO capturedCase = caseCaptor.getValue();


### PR DESCRIPTION
# Motivation and Context
This is changed is required as CC service needs to send the passPhrase (SALT) to EQ launcher to encrypt the response Id
# What has changed
A new property is added to application yaml and same is passed to EQ Launcher
AppConfig changed : added a new attribute.
 

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1205