### PR TITLE
CR-1284 Disallow estab type OTHER is already establishment exists

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -300,9 +300,10 @@ public class CaseServiceImpl implements CaseService {
     CaseContainerDTO caseDetails = getCaseFromRmOrCache(originalCaseId, true);
 
     if (modifyRequestDTO.getEstabType() == EstabType.OTHER
-        && !EstabType.OTHER.name().equalsIgnoreCase(caseDetails.getEstabType())) {
+        && EstabType.forCode(caseDetails.getEstabType()) != EstabType.OTHER) {
       throw new CTPException(Fault.BAD_REQUEST, ESTA_TYPE_OTHER_ERROR_MSG);
     }
+
     validateSurveyType(caseDetails);
     caseDetails.setCreatedDateTime(DateTimeUtil.nowUTC());
     CaseType requestedCaseType = modifyRequestDTO.getCaseType();

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -98,7 +98,7 @@ public class CaseServiceImpl implements CaseService {
   private static final String UNIT_LAUNCH_ERR_MSG =
       "A CE Manager form can only be launched against an establishment address not a UNIT.";
   private static final String CCS_CASE_ERROR_MSG = "Operation not permissible for a CCS Case";
-  private static final String ESTA_TYPE_OTHER_ERROR_MSG =
+  private static final String ESTAB_TYPE_OTHER_ERROR_MSG =
       "The pre-existing Establishment Type cannot be changed to OTHER";
   private static final List<DeliveryChannel> ALL_DELIVERY_CHANNELS =
       List.of(DeliveryChannel.POST, DeliveryChannel.SMS);
@@ -301,7 +301,7 @@ public class CaseServiceImpl implements CaseService {
 
     if (modifyRequestDTO.getEstabType() == EstabType.OTHER
         && EstabType.forCode(caseDetails.getEstabType()) != EstabType.OTHER) {
-      throw new CTPException(Fault.BAD_REQUEST, ESTA_TYPE_OTHER_ERROR_MSG);
+      throw new CTPException(Fault.BAD_REQUEST, ESTAB_TYPE_OTHER_ERROR_MSG);
     }
 
     validateSurveyType(caseDetails);

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -97,6 +97,8 @@ public class CaseServiceImpl implements CaseService {
   private static final String UNIT_LAUNCH_ERR_MSG =
       "A CE Manager form can only be launched against an establishment address not a UNIT.";
   private static final String CCS_CASE_ERROR_MSG = "Operation not permissible for a CCS Case";
+  private static final String ESTA_TYPE_OTHER_ERROR_MSG =
+      "The pre-existing Establishment Type cannot be changed to OTHER";
   private static final List<DeliveryChannel> ALL_DELIVERY_CHANNELS =
       List.of(DeliveryChannel.POST, DeliveryChannel.SMS);
 
@@ -295,6 +297,11 @@ public class CaseServiceImpl implements CaseService {
     UUID caseId = originalCaseId;
 
     CaseContainerDTO caseDetails = getCaseFromRmOrCache(originalCaseId, true);
+
+    if (modifyRequestDTO.getEstabType() == EstabType.OTHER
+        && !EstabType.OTHER.name().equalsIgnoreCase(caseDetails.getEstabType())) {
+      throw new CTPException(Fault.BAD_REQUEST, ESTA_TYPE_OTHER_ERROR_MSG);
+    }
     validateSurveyType(caseDetails);
     caseDetails.setCreatedDateTime(DateTimeUtil.nowUTC());
     CaseType requestedCaseType = modifyRequestDTO.getCaseType();

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
@@ -127,6 +127,7 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
 
     casesFromRm.get(0).setCaseType("HI");
     casesFromRm.get(1).setCaseType("HI");
+    casesFromRm.get(2).setCaseType("HI");
 
     mockCasesFromRm();
     mockNothingInTheCache();

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -17,6 +17,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -118,13 +119,37 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   }
 
   @Test
-  public void shouldReturnBadRequestWhenModifyHouseholdEstabTypeToOthers() throws Exception {
+  public void shouldReturnBadRequestWhenModifyHouseholdEstabTypeToOther() throws Exception {
     when(caseServiceClient.getCaseById(eq(UUID_0), eq(true)))
         .thenReturn(householdEstabTypeTypeCaseContainerDTO);
     requestDTO.setEstabType(EstabType.OTHER);
     CTPException e = assertThrows(CTPException.class, () -> target.modifyCase(requestDTO));
     assertEquals(Fault.BAD_REQUEST, e.getFault());
     assertEquals("The pre-existing Establishment Type cannot be changed to OTHER", e.getMessage());
+    verifyRmCaseCall(1);
+  }
+
+  @Test
+  public void shouldModifyNonExistEstabTypeToOther() throws Exception {
+    householdEstabTypeTypeCaseContainerDTO.setEstabType("floating palace");
+    when(caseServiceClient.getCaseById(eq(UUID_0), eq(true)))
+        .thenReturn(householdEstabTypeTypeCaseContainerDTO);
+    requestDTO.setEstabType(EstabType.OTHER);
+    CaseDTO response = target.modifyCase(requestDTO);
+    assertNotNull(response);
+    Assert.assertEquals(EstabType.OTHER, response.getEstabType());
+    verifyRmCaseCall(1);
+  }
+
+  @Test
+  public void shouldModifyOtherEstabTypeToOther() throws Exception {
+    householdEstabTypeTypeCaseContainerDTO.setEstabType(EstabType.OTHER.name());
+    when(caseServiceClient.getCaseById(eq(UUID_0), eq(true)))
+        .thenReturn(householdEstabTypeTypeCaseContainerDTO);
+    requestDTO.setEstabType(EstabType.OTHER);
+    CaseDTO response = target.modifyCase(requestDTO);
+    assertNotNull(response);
+    Assert.assertEquals(EstabType.OTHER, response.getEstabType());
     verifyRmCaseCall(1);
   }
 
@@ -313,6 +338,16 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
     verifyAddressForTypeChange(address);
 
     verifyEventNotSent(EventType.ADDRESS_MODIFIED);
+  }
+
+  @Test
+  public void shouldChangeAddressType_RequestOther_NonExistingOtherCE() throws Exception {
+    verifyAddressTypeChanged(CaseType.HH, EstabType.OTHER, "Oblivion Sky Tower", CaseType.CE);
+  }
+
+  @Test
+  public void shouldChangeAddressType_RequestOther_OtherCE() throws Exception {
+    verifyAddressTypeChanged(CaseType.HH, EstabType.OTHER, EstabType.OTHER.name(), CaseType.CE);
   }
 
   @Test

--- a/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.CaseContainerDTO.json
+++ b/src/test/resources/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/PackageFixture.CaseContainerDTO.json
@@ -92,6 +92,35 @@
     }
   ],
   "surveyType": "CCS"
+},
+{
+  "id": "7f03921a-7294-4a5a-8390-c4fc0516da1a",
+  "estabType": "Household",
+  "estabUprn": "344111441111",
+  "uprn": "344999999991",
+  "caseRef": "113400000000001",
+  "caseType": "CE",
+  "createdDateTime": "2019-05-15T18:09:41.343+01:00",
+  "lastUpdated": "2019-05-14T16:15:32.221+01:00",
+  "addressLine1": "3 High Street",
+  "addressLine2": "Burnsby",
+  "addressLine3": "Bigtown",
+  "townName": "Glumby",
+  "postcode": "G1 6AA",
+  "organisationName": "OX",
+  "addressLevel": "E",
+  "abpCode": "XX",
+  "region": "E",
+  "latitude": "5.40338",
+  "longitude": "6.17403",
+  "oa": "EE2",
+  "lsoa": "xlsoa",
+  "msoa": "xmsoa",
+  "lad": "H2",
+  "secureEstablishment": true,
+  "caseEvents": [
+  ],
+  "surveyType": "CENSUS"
 }
 ]
 


### PR DESCRIPTION
# Motivation and Context
Disallow CC to set estab type to OTHER if cases in RM or Cache is already existing establishment. 
The pre-existing Establishment Type cannot be changed to OTHER

# What has changed
Case Service is changed to add a check if there any establishment exists then it can not be changed to OTHER

# How to test?
Run put/cases endpoint with estabType as OTHER then if pre existing establishment is not OTHER it should throw BAD REQUEST with error message  "The pre-existing Establishment Type cannot be changed to OTHER"

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1284

