### PR TITLE
Adding a new query parameter to two calls

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
@@ -42,6 +42,7 @@ public class AddressServiceClientServiceImpl {
     queryParams.add("offset", Integer.toString(offset));
     queryParams.add("limit", Integer.toString(limit));
     queryParams.add("historical", "false");
+    queryParams.add("includeauxiliarysearch", "true");
     addEpoch(queryParams);
 
     // Ask Address Index to do an address search
@@ -67,6 +68,7 @@ public class AddressServiceClientServiceImpl {
     MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
     queryParams.add("offset", Integer.toString(offset));
     queryParams.add("limit", Integer.toString(limit));
+    queryParams.add("includeauxiliarysearch", "true");
     addEpoch(queryParams);
 
     // Ask Address Index to do postcode search

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.java
@@ -88,7 +88,8 @@ public class AddressServiceClientServiceImplTest {
     assertEquals("[100]", queryParams.get("limit").toString());
     assertEquals("[false]", queryParams.get("historical").toString());
     assertEquals("[99]", queryParams.get("epoch").toString());
-    assertEquals(5, queryParams.keySet().size());
+    assertEquals("[true]", queryParams.get("includeauxiliarysearch").toString());
+    assertEquals(6, queryParams.keySet().size());
   }
 
   @Test
@@ -120,7 +121,8 @@ public class AddressServiceClientServiceImplTest {
     assertEquals("[0]", queryParams.get("offset").toString());
     assertEquals("[100]", queryParams.get("limit").toString());
     assertEquals("[false]", queryParams.get("historical").toString());
-    assertEquals(4, queryParams.keySet().size());
+    assertEquals("[true]", queryParams.get("includeauxiliarysearch").toString());
+    assertEquals(5, queryParams.keySet().size());
   }
 
   @Test
@@ -149,7 +151,8 @@ public class AddressServiceClientServiceImplTest {
     assertEquals("[0]", queryParams.get("offset").toString());
     assertEquals("[100]", queryParams.get("limit").toString());
     assertEquals("[99]", queryParams.get("epoch").toString());
-    assertEquals(3, queryParams.keySet().size());
+    assertEquals("[true]", queryParams.get("includeauxiliarysearch").toString());
+    assertEquals(4, queryParams.keySet().size());
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
A downstream API has additional requirements for requests now.

# What has changed
Requests to /addresses and /addresses/postcode/{postcode} in AI now have a includeauxiliarysearch query param which we need to pass.

# How to test?
The relevant unit tests have been updated.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1107
