### PR TITLE
CR-1443 Add matchthreshold Parameter to AI Call and Update Unit Tests

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
@@ -43,6 +43,7 @@ public class AddressServiceClientServiceImpl {
     queryParams.add("limit", Integer.toString(limit));
     queryParams.add("historical", "false");
     queryParams.add("includeauxiliarysearch", "true");
+    queryParams.add("matchthreshold", "0");
     addEpoch(queryParams);
 
     // Ask Address Index to do an address search

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.java
@@ -89,7 +89,8 @@ public class AddressServiceClientServiceImplTest {
     assertEquals("[false]", queryParams.get("historical").toString());
     assertEquals("[99]", queryParams.get("epoch").toString());
     assertEquals("[true]", queryParams.get("includeauxiliarysearch").toString());
-    assertEquals(6, queryParams.keySet().size());
+    assertEquals("[0]", queryParams.get("matchthreshold").toString());
+    assertEquals(7, queryParams.keySet().size());
   }
 
   @Test
@@ -122,7 +123,8 @@ public class AddressServiceClientServiceImplTest {
     assertEquals("[100]", queryParams.get("limit").toString());
     assertEquals("[false]", queryParams.get("historical").toString());
     assertEquals("[true]", queryParams.get("includeauxiliarysearch").toString());
-    assertEquals(5, queryParams.keySet().size());
+    assertEquals("[0]", queryParams.get("matchthreshold").toString());
+    assertEquals(6, queryParams.keySet().size());
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The CR-1443 ticket describes the task as follows:

AIMs inform us that to ensure we get a fuller list of results from /addresses when calling AI using the 'includeauxiliarysearch' request param, we should use 'matchthreshold=0'.

This is only required for using the AI /addresses and NOT when using /addresses/postcode

# What has changed
<!--- What code changes has been made -->
The searchByAddress method in AddressServiceClientServiceImpl has been modified so that it now includes matchthreshold=0 as described above. 

Two JUnit tests have also been modified to check the new parameter. These are:
1. testAddressQueryProcessing()
2. testAddressQueryProcessingNoEpoch()

# How to test?
<!--- Describe in detail how you tested your changes. -->

Run rabbitmq, the mock case service, and this branch of the contact centre service.

Use Postman to send a GET request to the following URL:

http://localhost:8171/addresses?input=4%20skipton%20close

The matchthreshold=0 is added behind the scenes. Confirm that the results give you more than 1 address e.g.

{
    "dataVersion": "77",
    "addresses": [
        {
            "uprn": "100061542666",
            "formattedAddress": "4 SKIPTON CLOSE WINDLEYBURY GU16 6DG",
            "welshFormattedAddress": "4 SKIPTON CLOSE WINDLEYBURY GU16 6DG",
            "region": "E",
            "addressType": "HH",
            "estabType": "HOUSEHOLD",
            "estabDescription": "HOUSEHOLD"
        },
        {
            "uprn": "15078691",
            "formattedAddress": "4 Skipton Close, Northampton, NN4 0RB",
            "welshFormattedAddress": "4 Skipton Close, Northampton, NN4 0RB",
            "region": "E",
            "addressType": "HH",
            "estabType": "HOUSEHOLD",
            "estabDescription": "Household"
        },
        {
            "uprn": "10010611354",
            "formattedAddress": "4 Skipton Close, Castlefields, Runcorn, WA7 2SG",
            "welshFormattedAddress": "4 Skipton Close, Castlefields, Runcorn, WA7 2SG",
            "region": "E",
            "addressType": "HH",
            "estabType": "HOUSEHOLD",
            "estabDescription": "Household"
        },

and so on.

NB. Doing the same thing but with the master branch of ccsvc should only give 1 address currently, as follows:

{
    "dataVersion": "77",
    "addresses": [
        {
            "uprn": "100061542666",
            "formattedAddress": "4 SKIPTON CLOSE WINDLEYBURY GU16 6DG",
            "welshFormattedAddress": "4 SKIPTON CLOSE WINDLEYBURY GU16 6DG",
            "region": "E",
            "addressType": "HH",
            "estabType": "HOUSEHOLD",
            "estabDescription": "HOUSEHOLD"
        }
    ],
    "total": 1
}
