### PR TITLE
Cr 1479 reject invalid ccs ce questionnaire

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -8,13 +8,11 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Stream;
 import ma.glasnost.orika.MapperFacade;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.validator.routines.checkdigit.LuhnCheckDigit;
@@ -89,14 +87,13 @@ import uk.gov.ons.ctp.integration.eqlaunch.service.EqLaunchService;
 public class CaseServiceImpl implements CaseService {
 
   private static final Logger log = LoggerFactory.getLogger(CaseServiceImpl.class);
-  private static final Collection<String> VALID_REGIONS =
-      Stream.of(uk.gov.ons.ctp.integration.contactcentresvc.representation.Region.values())
-          .map(Enum::name)
-          .collect(toList());
   private static final String NI_LAUNCH_ERR_MSG =
       "All Northern Ireland calls from CE Managers are to be escalated to the NI management team.";
   private static final String UNIT_LAUNCH_ERR_MSG =
       "A CE Manager form can only be launched against an establishment address not a UNIT.";
+  private static final String CANNOT_LAUNCH_CCS_CASE_FOR_CE_MSG =
+      "Telephone capture feature is not available for CCS Communal establishment's. "
+          + "CCS CE's must submit their survey via CCS Paper Questionnaire";
   private static final String CCS_CASE_ERROR_MSG = "Operation not permissible for a CCS Case";
   private static final String ESTAB_TYPE_OTHER_ERROR_MSG =
       "The pre-existing Establishment Type cannot be changed to OTHER";
@@ -1167,8 +1164,8 @@ public class CaseServiceImpl implements CaseService {
         .with("formType", formType)
         .info("Have generated new questionnaireId");
 
-    if (caseType == CaseType.CE && !individual && FormType.C.name().equals(formType)) {
-      rejectInvalidLaunchCombinations(caseDetails.getRegion(), caseDetails.getAddressLevel());
+    if (caseType == CaseType.CE) {
+      rejectInvalidLaunchCombinationsForCE(caseDetails, individual, formType);
     }
 
     return newQuestionnaireIdDto;
@@ -1205,14 +1202,20 @@ public class CaseServiceImpl implements CaseService {
     }
   }
 
-  private void rejectInvalidLaunchCombinations(String region, String addressLevel)
-      throws CTPException {
-    if ("E".equals(addressLevel)) {
-      if ("N".equals(region)) {
-        throw new CTPException(Fault.BAD_REQUEST, NI_LAUNCH_ERR_MSG);
-      }
-    } else if ("U".equals(addressLevel)) {
-      if (VALID_REGIONS.contains(region)) {
+  private void rejectInvalidLaunchCombinationsForCE(
+      CaseContainerDTO caseDetails, boolean individual, String formType) throws CTPException {
+    if ("CCS".equalsIgnoreCase(caseDetails.getSurveyType())) {
+      throw new CTPException(Fault.RESOURCE_NOT_FOUND, CANNOT_LAUNCH_CCS_CASE_FOR_CE_MSG);
+    }
+
+    if (!individual && FormType.C.name().equals(formType)) {
+      String region = caseDetails.getRegion();
+      String addressLevel = caseDetails.getAddressLevel();
+      if ("E".equals(addressLevel)) {
+        if ("N".equals(region)) {
+          throw new CTPException(Fault.BAD_REQUEST, NI_LAUNCH_ERR_MSG);
+        }
+      } else if ("U".equals(addressLevel)) {
         throw new CTPException(Fault.BAD_REQUEST, UNIT_LAUNCH_ERR_MSG);
       }
     }


### PR DESCRIPTION
# Motivation and Context
Fixes a problem whereby CCS CE caseId's are not validated (rejected) in CCSvc, therefore passing them downstream to EQ to reject.

# What has changed
* validation to reject CCS CE caseID  when accessing launch endpoint with message as in JIRA
* remove misleading region validation (introduced in CR-907)
* it is agreed that the validation code, which is reused by the AD get UAC for caseId endpoint, is OK to be shared , since the AD endpoint will never handle CCS cases.

# How to test?
* go to CCSVc launch  endpoint with CaseId that is CCS and CE - should get 404 with message as in JIRA

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1479
