### PR TITLE
CR-1630 accept null UPRN for refusal endpoint

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -721,7 +721,10 @@ public class CaseServiceImpl implements CaseService {
     if (region != null) {
       address.setRegion(region.name());
     }
-    address.setUprn(Long.toString(refusalRequest.getUprn().getValue()));
+    UniquePropertyReferenceNumber uprn = refusalRequest.getUprn();
+    if (uprn != null) {
+      address.setUprn(Long.toString(uprn.getValue()));
+    }
     refusal.setAddress(address);
 
     return refusal;


### PR DESCRIPTION
# Motivation and Context
Fix a bug where optional field that is not supplied (UPRN) causes an NPE , and an error back to caller, when it should succeed.

# What has changed
- UPRN access guarded by check for null
- unit tests updated.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1630