### PR TITLE
CR-1479 move validation ahead of call to get questionnaireId

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1132,6 +1132,9 @@ public class CaseServiceImpl implements CaseService {
     if (!(caseType == CaseType.CE || caseType == CaseType.HH || caseType == CaseType.SPG)) {
       throw new CTPException(Fault.BAD_REQUEST, "Case type must be SPG, CE or HH");
     }
+    if (caseType == CaseType.CE && "CCS".equalsIgnoreCase(caseDetails.getSurveyType())) {
+      throw new CTPException(Fault.RESOURCE_NOT_FOUND, CANNOT_LAUNCH_CCS_CASE_FOR_CE_MSG);
+    }
 
     UUID parentCaseId = caseDetails.getId();
     UUID individualCaseId = null;
@@ -1207,10 +1210,6 @@ public class CaseServiceImpl implements CaseService {
 
   private void rejectInvalidLaunchCombinationsForCE(
       CaseContainerDTO caseDetails, boolean individual, String formType) throws CTPException {
-    if ("CCS".equalsIgnoreCase(caseDetails.getSurveyType())) {
-      throw new CTPException(Fault.RESOURCE_NOT_FOUND, CANNOT_LAUNCH_CCS_CASE_FOR_CE_MSG);
-    }
-
     if (!individual && FormType.C.name().equals(formType)) {
       String region = caseDetails.getRegion();
       String addressLevel = caseDetails.getAddressLevel();

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
@@ -6,7 +6,10 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.AN_AGENT_ID;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_QUESTIONNAIRE_ID;
 import static uk.gov.ons.ctp.integration.contactcentresvc.CaseServiceFixture.A_REGION;
@@ -122,6 +125,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
         caseDetails,
         "Telephone capture feature is not available for CCS Communal establishment's. CCS CE's must submit their survey via CCS Paper Questionnaire",
         Fault.RESOURCE_NOT_FOUND);
+    verifyCallToGetQuestionnaireIdNotCalled();
   }
 
   @Test
@@ -291,6 +295,10 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
     } else {
       assertNull(individualCaseIdCaptor.getValue());
     }
+  }
+
+  private void verifyCallToGetQuestionnaireIdNotCalled() {
+    verify(caseServiceClient, never()).getSingleUseQuestionnaireId(any(), anyBoolean(), any());
   }
 
   private void doLaunchTest(String caseType, boolean individual) throws Exception {


### PR DESCRIPTION
Bug fix.

The previous implementation for CR-1479 put the CE + CCS check after the call to get the QID  , so it fails just the same from the call to RM. 

This fix moves the check ahead of the call to get the QID.