### PR TITLE
CR-1692 make sure EstabType has known code for published event

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -497,7 +497,10 @@ public class CaseServiceImpl implements CaseService {
     newAddress.setCollectionExerciseId(appConfig.getCollectionExerciseId());
     newAddress.setCeExpectedCapacity(ceExpectedCapacity);
 
-    EstabType aimsEstabType = EstabType.forCode(newAddress.getAddress().getEstabType());
+    Address addrDetails = newAddress.getAddress();
+    EstabType aimsEstabType = EstabType.forCode(addrDetails.getEstabType());
+    addrDetails.setEstabType(aimsEstabType.getCode());
+
     Optional<AddressType> addressTypeMaybe = aimsEstabType.getAddressType();
 
     AddressType addressType =
@@ -505,9 +508,9 @@ public class CaseServiceImpl implements CaseService {
             ? addressTypeMaybe.get()
             : AddressType.valueOf(address.getCensusAddressType());
     if (addressType == AddressType.HH || addressType == AddressType.SPG) {
-      newAddress.getAddress().setAddressLevel(AddressLevel.U.name());
+      addrDetails.setAddressLevel(AddressLevel.U.name());
     } else {
-      newAddress.getAddress().setAddressLevel(AddressLevel.E.name());
+      addrDetails.setAddressLevel(AddressLevel.E.name());
     }
 
     NewAddress payload = new NewAddress();

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
@@ -435,8 +435,8 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
     CollectionCaseNewAddress newAddress =
         mapperFacade.map(addressFromAI, CollectionCaseNewAddress.class);
     newAddress.setId(cachedCase.getId());
-    verifyNewAddressEventSent(
-        addressFromAI.getCensusAddressType(), addressFromAI.getCensusEstabType(), newAddress);
+    String expectedEstabType = EstabType.forCode(addressFromAI.getCensusEstabType()).getCode();
+    verifyNewAddressEventSent(addressFromAI.getCensusAddressType(), expectedEstabType, newAddress);
   }
 
   private void verifyCachedCaseContent(


### PR DESCRIPTION
# Motivation and Context
RM rabbit events need to receive EstabType known code,  not mixed case as sometimes we have been sending (originating from AIMS).

# What has changed

Fix estabType published for NEW_ADDRESS_REPORTED event

https://collaborate2.ons.gov.uk/jira/browse/CR-1692