### PR TITLE
CR-1774 add unit level CE validation before RM call to get QID to avo…

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1136,8 +1136,12 @@ public class CaseServiceImpl implements CaseService {
     if (!(caseType == CaseType.CE || caseType == CaseType.HH || caseType == CaseType.SPG)) {
       throw new CTPException(Fault.BAD_REQUEST, "Case type must be SPG, CE or HH");
     }
-    if (caseType == CaseType.CE && "CCS".equalsIgnoreCase(caseDetails.getSurveyType())) {
-      throw new CTPException(Fault.BAD_REQUEST, CANNOT_LAUNCH_CCS_CASE_FOR_CE_MSG);
+    if (caseType == CaseType.CE) {
+      if ("CCS".equalsIgnoreCase(caseDetails.getSurveyType())) {
+        throw new CTPException(Fault.BAD_REQUEST, CANNOT_LAUNCH_CCS_CASE_FOR_CE_MSG);
+      } else if (!individual && "U".equals(caseDetails.getAddressLevel())) {
+        throw new CTPException(Fault.BAD_REQUEST, UNIT_LAUNCH_ERR_MSG);
+      }
     }
 
     UUID parentCaseId = caseDetails.getId();
@@ -1221,8 +1225,6 @@ public class CaseServiceImpl implements CaseService {
         if ("N".equals(region)) {
           throw new CTPException(Fault.BAD_REQUEST, NI_LAUNCH_ERR_MSG);
         }
-      } else if ("U".equals(addressLevel)) {
-        throw new CTPException(Fault.BAD_REQUEST, UNIT_LAUNCH_ERR_MSG);
       }
     }
   }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetUACTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetUACTest.java
@@ -38,7 +38,8 @@ public class CaseServiceImplGetUACTest extends CaseServiceImplTestBase {
 
   @Test
   public void testGetUACCECase() throws Exception {
-    doGetUACTest("CE", false);
+    mockGetCaseById("CE", "E", A_REGION.name());
+    doGetUACTest(false, FormType.C);
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
@@ -73,7 +73,30 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
 
   @Test
   public void testLaunchCECase() throws Exception {
-    doLaunchTest("CE", false);
+    CaseContainerDTO caseFromCaseService = mockGetCaseById("CE", "E", A_REGION.name());
+    doLaunchTest(false, caseFromCaseService, FormType.H);
+  }
+
+  @Test
+  public void shouldLaunchCECaseForNonIndividualInNorthernIrelandWithFormTypeNotC()
+      throws Exception {
+    CaseContainerDTO caseFromCaseService = mockGetCaseById("CE", "E", "N");
+    doLaunchTest(false, caseFromCaseService, FormType.H);
+  }
+
+  // a unit test to increase code-coverage. Not defined what we do with unknown address-level.
+  @Test
+  public void shouldLaunchCECaseForNonIndividualUnknownLevelAddressInNorthernIreland()
+      throws Exception {
+    CaseContainerDTO caseFromCaseService = mockGetCaseById("CE", "X", "N");
+    doLaunchTest(false, caseFromCaseService, FormType.C);
+  }
+
+  // a unit test to increase code-coverage. Not defined what we do with unknown address-level.
+  @Test
+  public void testLaunchCECaseWithUnknownAddressLevel() throws Exception {
+    CaseContainerDTO caseFromCaseService = mockGetCaseById("CE", "X", A_REGION.name());
+    doLaunchTest(false, caseFromCaseService, FormType.H);
   }
 
   @Test
@@ -115,6 +138,12 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
     CaseContainerDTO caseDetails = mockGetCaseById("HH", "E", A_REGION.name());
     caseDetails.setSurveyType("CCS");
     doLaunchTest(false, caseDetails, FormType.H);
+  }
+
+  @Test
+  public void shouldLaunchIndividualUnitLevelCaseForCE() throws Exception {
+    CaseContainerDTO caseDetails = mockGetCaseById("CE", "U", A_REGION.name());
+    doLaunchTest(true, caseDetails, FormType.C);
   }
 
   @Test
@@ -188,6 +217,7 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
         dto,
         "A CE Manager form can only be launched against an establishment address not a UNIT.",
         Fault.BAD_REQUEST);
+    verifyCallToGetQuestionnaireIdNotCalled();
   }
 
   @Test


### PR DESCRIPTION
…id RM failure, and improve validation message

# Motivation and Context
On 2nd and 4th March a few errors lines were logged because RM failed validation when we request a new QID when Serco asks CCSvc  for Launch URL .

On inspection we can see that validation we had intended to take place for rejecting non-individual, CE case type , with UNIT address-level is not being reached and the desired informative message not delivered.

This fix rectifies this.

# What has changed
Validation moved before the RM call in the CCSvc path.

# How to test?
- unit tests
- run in deployed environment and request Launch URL for case type that is CE, UNIT address leve, and non-individual . It should fail with explanatory message, not the generic message, and no error line should be logged.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1774

Incident: INC0012476