### PR TITLE
Cr 1795 cc bf postcodes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.134</version>
+      <version>0.0.135-CR1795-SNAPSHOT</version>
     </dependency>
 
     <!-- WARNING WARNING WARNING The CCCucmber project has this dependancy

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.135-CR1795-SNAPSHOT</version>
+      <version>0.0.135</version>
     </dependency>
 
     <!-- WARNING WARNING WARNING The CCCucmber project has this dependancy

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
@@ -187,7 +187,7 @@ public final class AddressEndpointTest {
 
   @Test
   public void validateBritishForcesPostcodeQueryResponseJson() throws Exception {
-    assertOk("/addresses/postcode?postcode=BF1 4NY");  // HMS Sutherland
+    assertOk("/addresses/postcode?postcode=BF1 4NY"); // HMS Sutherland
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
@@ -193,7 +193,7 @@ public final class AddressEndpointTest {
         .andExpect(status().is(HttpStatus.SC_BAD_REQUEST))
         .andExpect(content().string(containsString("rejected value [BF1 4NY]")));
   }
- 
+
   @Test
   public void rejectBFPOPostcode() throws Exception {
     mockMvc

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
@@ -186,6 +186,16 @@ public final class AddressEndpointTest {
   }
 
   @Test
+  public void validateBritishForcesPostcodeQueryResponseJson() throws Exception {
+    assertOk("/addresses/postcode?postcode=BF1 4NY");  // HMS Sutherland
+  }
+
+  @Test
+  public void rejectBFPOPostcode() throws Exception {
+    assertOk("/addresses/postcode?postcode=BFPO 123");
+  }
+
+  @Test
   public void rejectPostcodeQueryMissingPostcode() throws Exception {
     mockMvc
         .perform(get("/addresses/postcode"))

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
@@ -193,7 +193,7 @@ public final class AddressEndpointTest {
         .andExpect(status().is(HttpStatus.SC_BAD_REQUEST))
         .andExpect(content().string(containsString("rejected value [BF1 4NY]")));
   }
-
+ 
   @Test
   public void rejectBFPOPostcode() throws Exception {
     mockMvc


### PR DESCRIPTION
This change uses the latest CC API which has updated regex to block BFPO postcodes.

Changes:

- Added unit test to prove that BFPO postcodes are rejected.
- Unit test for BF postcodes which were temporarily added (also rejected)
- Fixed existing bug in unit tests