### PR TITLE
Cr 1810 prevent invalid ni ce launches

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -555,7 +555,7 @@ public class CaseServiceImpl implements CaseService {
   }
 
   private Region convertRegion(CaseContainerDTO caseDetails) {
-    return Region.valueOf(caseDetails.getRegion().substring(0, 1));
+    return Region.valueOf(caseDetails.getRegion().substring(0, 1).toUpperCase());
   }
 
   /**
@@ -1323,10 +1323,10 @@ public class CaseServiceImpl implements CaseService {
   private void rejectInvalidLaunchCombinationsForCE(
       CaseContainerDTO caseDetails, boolean individual, String formType) throws CTPException {
     if (!individual && FormType.C.name().equals(formType)) {
-      String region = caseDetails.getRegion();
+      Region region = convertRegion(caseDetails);
       String addressLevel = caseDetails.getAddressLevel();
       if ("E".equals(addressLevel)) {
-        if ("N".equals(region)) {
+        if (Region.N == region) {
           throw new CTPException(Fault.BAD_REQUEST, NI_LAUNCH_ERR_MSG);
         }
       }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplLaunchTest.java
@@ -271,13 +271,27 @@ public class CaseServiceImplLaunchTest extends CaseServiceImplTestBase {
     assertThatCeManagerFormFromUnitRegionIsRejected(dto);
   }
 
-  @Test
-  public void shouldRejectCeManagerFormFromEstabRegionN() {
-    CaseContainerDTO dto = mockGetCaseById("CE", "E", "N");
+  private void assertRejectCeManagerFormFromEstabRegionN(String region) {
+    CaseContainerDTO dto = mockGetCaseById("CE", "E", region);
     assertThatInvalidLaunchComboIsRejected(
         dto,
         "All Northern Ireland calls from CE Managers are to be escalated to the NI management team.",
         Fault.BAD_REQUEST);
+  }
+
+  @Test
+  public void shouldRejectCeManagerFormFromEstabRegionN() {
+    assertRejectCeManagerFormFromEstabRegionN("N");
+  }
+
+  @Test
+  public void shouldRejectCeManagerFormFromEstab_lowercaseRegionN() {
+    assertRejectCeManagerFormFromEstabRegionN("n");
+  }
+
+  @Test
+  public void shouldRejectCeManagerFormFromEstab_regionNWithTrailingChars() {
+    assertRejectCeManagerFormFromEstabRegionN("N0123");
   }
 
   private void verifyEqLaunchJwe(

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -394,19 +394,33 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
     verifyAddressTypeChanged(CaseType.HH, EstabType.HOUSEHOLD, "Oblivion Sky Tower", CaseType.SPG);
   }
 
-  @Test
-  public void shouldRejectNorthernIrelandChangeFromHouseholdToCE() {
+  private void assertRejectNorthernIrelandChangeFromHouseholdToCE(String region) {
     requestDTO.setCaseType(CaseType.CE);
     requestDTO.setEstabType(EstabType.CARE_HOME);
     caseContainerDTO.setEstabType(EstabType.HOUSEHOLD.getCode());
     caseContainerDTO.setCaseType(CaseType.HH.name());
-    caseContainerDTO.setRegion(Region.N.name());
+    caseContainerDTO.setRegion(region);
     mockRmHasCase();
     CTPException e = assertThrows(CTPException.class, () -> target.modifyCase(requestDTO));
     assertEquals(Fault.BAD_REQUEST, e.getFault());
     assertEquals(
         "All queries relating to Communal Establishments in Northern Ireland should be escalated to NISRA HQ",
         e.getMessage());
+  }
+
+  @Test
+  public void shouldRejectNorthernIrelandChangeFromHouseholdToCE_regionN() {
+    assertRejectNorthernIrelandChangeFromHouseholdToCE("N");
+  }
+
+  @Test
+  public void shouldRejectNorthernIrelandChangeFromHouseholdToCE_regionLowerCaseN() {
+    assertRejectNorthernIrelandChangeFromHouseholdToCE("n");
+  }
+
+  @Test
+  public void shouldRejectNorthernIrelandChangeFromHouseholdToCE_regionWithTrailingChars() {
+    assertRejectNorthernIrelandChangeFromHouseholdToCE("N01234");
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
A bug in the code where region returned from RM needs to be stripped of trailing characters and uppercase in order to compare with our normal Region names (eg "N" for northern ireland).  This has allowed us to skip a validation check and send invalid launch combinations to EQ.

This is the fix

# What has changed
- Use existing region converter , updated to ensure upper-case
- enhanced unit tests

# How to test
- you will need case details coming from RM (or case simulator) with a region that is Northern Ireland with trailing chars, eg "N123" and CE
- Try to launch it via CCSvc with individual=false
- If the fix is in place then validation should return correct error message, otherwise it will go through to EQ to fail.

https://collaborate2.ons.gov.uk/jira/browse/CR-1810