### PR TITLE
Cr 1812 improve logging for region override on new case

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1097,7 +1097,7 @@ public class CaseServiceImpl implements CaseService {
       } catch (ResponseStatusException e) {
         // Something went wrong calling AI.
         // Never mind, we'll still be able to use the Serco supplied region
-        log.with(postcode).warn("Failed to call AI to resolve region");
+        log.with("postcode", postcode).warn("Failed to call AI to resolve region");
       }
 
       if (addressIndexResponse != null) {
@@ -1107,7 +1107,7 @@ public class CaseServiceImpl implements CaseService {
           // Found an address. Fail if Scottish otherwise use its region
           String countryCode = addresses.get(0).getCensus().getCountryCode();
           if (countryCode != null && countryCode.equals("S")) {
-            log.with(postcode).info("Rejecting as it's a Scottish address");
+            log.with("postcode", postcode).info("Rejecting as it's a Scottish address");
             throw new CTPException(
                 Fault.BAD_REQUEST, "Scottish addresses are not valid for Census");
           }
@@ -1126,19 +1126,21 @@ public class CaseServiceImpl implements CaseService {
     uk.gov.ons.ctp.integration.contactcentresvc.representation.Region regionForNewCase = null;
     if (ccRegion == null) {
       // CC failed to find the region
-      log.with(sercoRegion)
+      log.with("sercoRegion", sercoRegion)
           .info(
               "Unable to determine region for new case."
                   + " Falling back to using Serco provided region");
       regionForNewCase = sercoRegion;
     } else if (sercoRegion == ccRegion) {
       // CC agrees with Serco supplied region
-      log.with(sercoRegion).with(ccRegion).info("Using Serco provided region for new case");
+      log.with("sercoRegion", sercoRegion)
+          .with("ccRegion", ccRegion)
+          .info("Using Serco provided region for new case");
       regionForNewCase = sercoRegion;
     } else {
       // CC and Serco differ, so override Serco region
-      log.with(sercoRegion)
-          .with(ccRegion)
+      log.with("sercoRegion", sercoRegion)
+          .with("ccRegion", ccRegion)
           .info("Overriding Serco region with cc region for new case");
       regionForNewCase = ccRegion;
     }

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1069,16 +1069,15 @@ public class CaseServiceImpl implements CaseService {
 
   private uk.gov.ons.ctp.integration.contactcentresvc.representation.Region determineActualRegion(
       NewCaseRequestDTO caseRequestDTO) throws CTPException {
-    uk.gov.ons.ctp.integration.contactcentresvc.representation.Region requestedRegion =
+    uk.gov.ons.ctp.integration.contactcentresvc.representation.Region sercoRegion =
         caseRequestDTO.getRegion();
-    uk.gov.ons.ctp.integration.contactcentresvc.representation.Region actualRegion = null;
+    uk.gov.ons.ctp.integration.contactcentresvc.representation.Region ccRegion = null;
 
     String postcode = caseRequestDTO.getPostcode();
     String postcodeArea = postcode.substring(0, 2).toUpperCase();
 
     if (postcodeArea.equals("BT")) {
-      log.with(postcode).info("Forcing region to Northern Ireland");
-      actualRegion = uk.gov.ons.ctp.integration.contactcentresvc.representation.Region.N;
+      ccRegion = uk.gov.ons.ctp.integration.contactcentresvc.representation.Region.N;
 
     } else {
       // Get ready to call AI to find the region for the specified postcode
@@ -1114,7 +1113,8 @@ public class CaseServiceImpl implements CaseService {
           }
 
           if (countryCode != null) {
-            actualRegion =
+            // Use the region as specified by AI
+            ccRegion =
                 uk.gov.ons.ctp.integration.contactcentresvc.representation.Region.valueOf(
                     countryCode);
           }
@@ -1122,12 +1122,26 @@ public class CaseServiceImpl implements CaseService {
       }
     }
 
-    if (actualRegion == null) {
-      log.with(requestedRegion).debug("Falling back to using Serco provided region");
-      actualRegion = requestedRegion;
+    // Decide if we are using the Serco or the CC calculated region
+    uk.gov.ons.ctp.integration.contactcentresvc.representation.Region regionForNewCase = null;
+    if (ccRegion == null) {
+      // Failed to find the region
+      log.with(sercoRegion)
+          .info(
+              "Unable to determine region for new case."
+                  + " Falling back to using Serco provided region");
+      regionForNewCase = sercoRegion;
+    } else if (sercoRegion == ccRegion) {
+      log.with(sercoRegion).with(ccRegion).info("Using Serco provided region for new case");
+      regionForNewCase = sercoRegion;
+    } else {
+      log.with(sercoRegion)
+          .with(ccRegion)
+          .info("Overriding Serco region with cc region for new case");
+      regionForNewCase = ccRegion;
     }
 
-    return actualRegion;
+    return regionForNewCase;
   }
 
   private MultiValueMap<String, String> addEpoch(MultiValueMap<String, String> queryParams) {

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -1125,16 +1125,18 @@ public class CaseServiceImpl implements CaseService {
     // Decide if we are using the Serco or the CC calculated region
     uk.gov.ons.ctp.integration.contactcentresvc.representation.Region regionForNewCase = null;
     if (ccRegion == null) {
-      // Failed to find the region
+      // CC failed to find the region
       log.with(sercoRegion)
           .info(
               "Unable to determine region for new case."
                   + " Falling back to using Serco provided region");
       regionForNewCase = sercoRegion;
     } else if (sercoRegion == ccRegion) {
+      // CC agrees with Serco supplied region
       log.with(sercoRegion).with(ccRegion).info("Using Serco provided region for new case");
       regionForNewCase = sercoRegion;
     } else {
+      // CC and Serco differ, so override Serco region
       log.with(sercoRegion)
           .with(ccRegion)
           .info("Overriding Serco region with cc region for new case");


### PR DESCRIPTION
Improve logging for region lookup so that we can use the logging to find out how often Serco attach the wrong region, etc.