### PR TITLE
Cr 1814 fix trailing spaces

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.136-SNAPSHOT</version>
+      <version>0.0.136</version>
     </dependency>
 
     <!-- WARNING WARNING WARNING The CCCucmber project has this dependancy

--- a/pom.xml
+++ b/pom.xml
@@ -129,7 +129,7 @@
     <dependency>
       <groupId>uk.gov.ons.ctp.integration</groupId>
       <artifactId>contactcentreserviceapi</artifactId>
-      <version>0.0.135</version>
+      <version>0.0.136-SNAPSHOT</version>
     </dependency>
 
     <!-- WARNING WARNING WARNING The CCCucmber project has this dependancy

--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressindex/AddressServiceClientServiceImpl.java
@@ -34,7 +34,7 @@ public class AddressServiceClientServiceImpl {
       log.debug("Delegating address search to AddressIndex service");
     }
 
-    String input = addressQueryRequest.getInput();
+    String input = addressQueryRequest.getInput().trim();
     int offset = addressQueryRequest.getOffset();
     int limit = addressQueryRequest.getLimit();
 

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/client/addressIndex/AddressServiceClientServiceImplTest.java
@@ -94,6 +94,32 @@ public class AddressServiceClientServiceImplTest {
   }
 
   @Test
+  public void shouldTrimInputBeforeSearch() throws Exception {
+    String input = "Susanne";
+    String paddedInput = "     " + input + "       ";
+
+    // Build results to be returned from search
+    AddressIndexSearchResultsDTO resultsFromAddressIndex =
+        FixtureHelper.loadClassFixtures(AddressIndexSearchResultsDTO[].class).get(0);
+    Mockito.when(
+            restClient.getResource(
+                eq(ADDRESS_QUERY_PATH),
+                eq(AddressIndexSearchResultsDTO.class),
+                any(),
+                any(),
+                any()))
+        .thenReturn(resultsFromAddressIndex);
+
+    AddressQueryRequestDTO request = AddressQueryRequestDTO.create(paddedInput, 0, 100);
+    AddressIndexSearchResultsDTO results = addressClientService.searchByAddress(request);
+    assertEquals(4, results.getResponse().getAddresses().size());
+
+    Mockito.verify(restClient).getResource(any(), any(), any(), queryParamsCaptor.capture(), any());
+    MultiValueMap<String, String> queryParams = queryParamsCaptor.getValue();
+    assertEquals("[" + input + "]", queryParams.get("input").toString());
+  }
+
+  @Test
   public void testAddressQueryProcessingNoEpoch() throws Exception {
     addressIndexSettings.setEpoch("");
     // Build results to be returned from search

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/endpoint/AddressEndpointTest.java
@@ -11,13 +11,15 @@ import static uk.gov.ons.ctp.common.utility.MockMvcControllerAdviceHelper.mockAd
 
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.MockitoJUnitRunner;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -30,6 +32,7 @@ import uk.gov.ons.ctp.integration.contactcentresvc.representation.AddressQueryRe
 import uk.gov.ons.ctp.integration.contactcentresvc.service.AddressService;
 
 /** Contact Centre Data endpoint Unit tests */
+@RunWith(MockitoJUnitRunner.class)
 public final class AddressEndpointTest {
 
   private static final String DATA_VERSION = "39";
@@ -60,8 +63,6 @@ public final class AddressEndpointTest {
    */
   @Before
   public void setUp() throws Exception {
-    MockitoAnnotations.initMocks(this);
-
     this.mockMvc =
         MockMvcBuilders.standaloneSetup(addressEndpoint)
             .setHandlerExceptionResolvers(mockAdviceFor(RestExceptionHandler.class))
@@ -72,6 +73,21 @@ public final class AddressEndpointTest {
   @Test
   public void validateAddressQueryResponseJson() throws Exception {
     assertOk("/addresses?input=Parks");
+  }
+
+  @Test
+  public void validateAddressQueryInputMaxLength() throws Exception {
+    String input = StringUtils.repeat('x', 250);
+    assertOk("/addresses?input=" + input);
+  }
+
+  @Test
+  public void rejectAddressQueryInputTooLong() throws Exception {
+    String input = StringUtils.repeat('x', 251);
+    mockMvc
+        .perform(get("/addresses?input=" + input))
+        .andExpect(content().string(containsString("field 'input'")))
+        .andExpect(content().string(containsString("must be between 0 and 250")));
   }
 
   @Test


### PR DESCRIPTION
# Motivation and Context
- Avoid failed call to AIMS due to lots of trailing white space
- restrict address search input to 250 chars in line with swagger

# What has changed
- pick up latest CCAPI to enforce 250 limit
- trim input before sending to AIMS
- unit tests

# How to test?
- unit tests
- postman on address search endpoint. Try long inputs or ones with surrounding white space.

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1814
