### PR TITLE
CR-1827 guard against null EstabType from RM which caused NPEs

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -921,22 +921,28 @@ public class CaseServiceImpl implements CaseService {
 
   private CaseDTO mapCaseContainerDTO(CaseContainerDTO caseDetails) {
     CaseDTO caseServiceResponse = caseDTOMapper.map(caseDetails, CaseDTO.class);
-    caseServiceResponse.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
-    caseServiceResponse.setEstabType(EstabType.forCode(caseServiceResponse.getEstabDescription()));
-
-    return caseServiceResponse;
+    return adaptCaseDTO(caseServiceResponse);
   }
 
   private List<CaseDTO> mapCaseContainerDTOList(List<CaseContainerDTO> casesToReturn) {
     List<CaseDTO> caseServiceListResponse = caseDTOMapper.mapAsList(casesToReturn, CaseDTO.class);
-
     for (CaseDTO caseServiceResponse : caseServiceListResponse) {
-      caseServiceResponse.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
+      adaptCaseDTO(caseServiceResponse);
+    }
+    return caseServiceListResponse;
+  }
+
+  private CaseDTO adaptCaseDTO(CaseDTO caseServiceResponse) {
+    caseServiceResponse.setAllowedDeliveryChannels(ALL_DELIVERY_CHANNELS);
+    if (null == caseServiceResponse.getEstabDescription()) {
+      String caseType = caseServiceResponse.getCaseType();
+      caseServiceResponse.setEstabType(
+          CaseType.HH.name().equals(caseType) ? EstabType.HOUSEHOLD : EstabType.OTHER);
+    } else {
       caseServiceResponse.setEstabType(
           EstabType.forCode(caseServiceResponse.getEstabDescription()));
     }
-
-    return caseServiceListResponse;
+    return caseServiceResponse;
   }
 
   private CaseDTO getLatestCaseById(UUID caseId, Boolean getCaseEvents) throws CTPException {

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByCaseRefTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByCaseRefTest.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.ons.ctp.common.FixtureHelper;
 import uk.gov.ons.ctp.common.domain.CaseType;
+import uk.gov.ons.ctp.common.domain.EstabType;
 import uk.gov.ons.ctp.common.domain.UniquePropertyReferenceNumber;
 import uk.gov.ons.ctp.common.error.CTPException;
 import uk.gov.ons.ctp.integration.caseapiclient.caseservice.model.CaseContainerDTO;
@@ -123,6 +124,30 @@ public class CaseServiceImplGetCaseByCaseRefTest extends CaseServiceImplTestBase
     acceptLuhn(VALID_CASE_REF);
     acceptLuhn(100000009);
     acceptLuhn(999999998);
+  }
+
+  @Test
+  public void shouldAdaptNullEstabTypeToHousehold() throws Exception {
+    CaseContainerDTO caseFromCaseService = casesFromCaseService().get(0);
+    caseFromCaseService.setCaseType(CaseType.HH.name());
+    caseFromCaseService.setEstabType(null);
+    Mockito.when(caseServiceClient.getCaseByCaseRef(any(), any())).thenReturn(caseFromCaseService);
+
+    CaseQueryRequestDTO requestParams = new CaseQueryRequestDTO(true);
+    CaseDTO results = target.getCaseByCaseReference(VALID_CASE_REF, requestParams);
+    assertEquals(EstabType.HOUSEHOLD, results.getEstabType());
+  }
+
+  @Test
+  public void shouldAdaptNullEstabTypeToOther() throws Exception {
+    CaseContainerDTO caseFromCaseService = casesFromCaseService().get(0);
+    caseFromCaseService.setCaseType(CaseType.CE.name());
+    caseFromCaseService.setEstabType(null);
+    Mockito.when(caseServiceClient.getCaseByCaseRef(any(), any())).thenReturn(caseFromCaseService);
+
+    CaseQueryRequestDTO requestParams = new CaseQueryRequestDTO(true);
+    CaseDTO results = target.getCaseByCaseReference(VALID_CASE_REF, requestParams);
+    assertEquals(EstabType.OTHER, results.getEstabType());
   }
 
   private void doTestGetCaseByCaseRef(CaseType caseType, boolean caseEvents) throws Exception {

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByIdTest.java
@@ -90,6 +90,30 @@ public class CaseServiceImplGetCaseByIdTest extends CaseServiceImplTestBase {
   }
 
   @Test
+  public void shouldAdaptNullEstabTypeToHousehold() throws Exception {
+    CaseContainerDTO caseFromCaseService = casesFromCaseService().get(0);
+    caseFromCaseService.setEstabType(null);
+    caseFromCaseService.setCaseType(CaseType.HH.name());
+    Mockito.when(caseServiceClient.getCaseById(eq(UUID_0), any())).thenReturn(caseFromCaseService);
+
+    CaseQueryRequestDTO requestParams = new CaseQueryRequestDTO(true);
+    CaseDTO results = target.getCaseById(UUID_0, requestParams);
+    assertEquals(EstabType.HOUSEHOLD, results.getEstabType());
+  }
+
+  @Test
+  public void shouldAdaptNullEstabTypeToOther() throws Exception {
+    CaseContainerDTO caseFromCaseService = casesFromCaseService().get(0);
+    caseFromCaseService.setCaseType(CaseType.CE.name());
+    caseFromCaseService.setEstabType(null);
+    Mockito.when(caseServiceClient.getCaseById(eq(UUID_0), any())).thenReturn(caseFromCaseService);
+
+    CaseQueryRequestDTO requestParams = new CaseQueryRequestDTO(true);
+    CaseDTO results = target.getCaseById(UUID_0, requestParams);
+    assertEquals(EstabType.OTHER, results.getEstabType());
+  }
+
+  @Test
   public void shouldGetSecureEstablishmentByCaseId() throws CTPException {
     CaseContainerDTO caseFromCaseService = casesFromCaseService().get(1);
     Mockito.when(caseServiceClient.getCaseById(eq(UUID_1), any())).thenReturn(caseFromCaseService);

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplGetCaseByUprnTest.java
@@ -94,6 +94,24 @@ public class CaseServiceImplGetCaseByUprnTest extends CaseServiceImplTestBase {
   }
 
   @Test
+  public void shouldHandleNullEstabTypeFromRmAndConvertToHH() throws Exception {
+    casesFromRm.get(0).setCaseType(CaseType.HH.name());
+    casesFromRm.get(0).setEstabType(null);
+    mockCasesFromRm();
+    CaseDTO result = getCasesByUprn(true);
+    assertEquals(EstabType.HOUSEHOLD, result.getEstabType());
+  }
+
+  @Test
+  public void shouldHandleNullEstabTypeFromRmAndConvertToOTHER() throws Exception {
+    casesFromRm.get(0).setCaseType(CaseType.CE.name());
+    casesFromRm.get(0).setEstabType(null);
+    mockCasesFromRm();
+    CaseDTO result = getCasesByUprn(true);
+    assertEquals(EstabType.OTHER, result.getEstabType());
+  }
+
+  @Test
   public void testGetCaseByUprn_withCaseDetailsForCaseTypeCE() throws Exception {
     casesFromRm.get(1).setCaseType(CaseType.CE.name());
     setLastUpdated(casesFromRm.get(0), 2020, 5, 14);


### PR DESCRIPTION
# Motivation and Context
CCSvc has seen lots of EstabType NPE's due to RM having null EstabType ,  and these are increasing due to Field Service activity. This code provides guards and an adaption described in CR-1827 / CR-1773.

# What has changed
Check for EstabType Null from RM and ensure correct adaption done.

