### PR TITLE
Cr 1841 more estab type npe fixes

### DIFF
--- a/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
+++ b/src/main/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImpl.java
@@ -341,6 +341,7 @@ public class CaseServiceImpl implements CaseService {
     CaseContainerDTO caseDetails = getCaseFromRmOrCache(originalCaseId, true);
 
     if (modifyRequestDTO.getEstabType() == EstabType.OTHER
+        && caseDetails.getEstabType() != null
         && EstabType.forCode(caseDetails.getEstabType()) != EstabType.OTHER) {
       throw new CTPException(Fault.BAD_REQUEST, ESTAB_TYPE_OTHER_ERROR_MSG);
     }

--- a/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/contactcentresvc/service/impl/CaseServiceImplModifyCaseTest.java
@@ -154,6 +154,30 @@ public class CaseServiceImplModifyCaseTest extends CaseServiceImplTestBase {
   }
 
   @Test
+  public void shouldModifyNullEstabTypeToOther() throws Exception {
+    householdEstabTypeTypeCaseContainerDTO.setEstabType(null);
+    when(caseServiceClient.getCaseById(eq(UUID_0), eq(true)))
+        .thenReturn(householdEstabTypeTypeCaseContainerDTO);
+    requestDTO.setEstabType(EstabType.OTHER);
+    CaseDTO response = target.modifyCase(requestDTO);
+    assertNotNull(response);
+    Assert.assertEquals(EstabType.OTHER, response.getEstabType());
+    verifyRmCaseCall(1);
+  }
+
+  @Test
+  public void shouldModifyNullEstabTypeToHousehold() throws Exception {
+    householdEstabTypeTypeCaseContainerDTO.setEstabType(null);
+    when(caseServiceClient.getCaseById(eq(UUID_0), eq(true)))
+        .thenReturn(householdEstabTypeTypeCaseContainerDTO);
+    requestDTO.setEstabType(EstabType.HOUSEHOLD);
+    CaseDTO response = target.modifyCase(requestDTO);
+    assertNotNull(response);
+    Assert.assertEquals(EstabType.HOUSEHOLD, response.getEstabType());
+    verifyRmCaseCall(1);
+  }
+
+  @Test
   public void shouldAcceptCompatibleCaseTypeAndEstabType() throws Exception {
     mockRmHasCase();
     verifyAcceptCompatible(EstabType.APPROVED_PREMISES, CaseType.CE);


### PR DESCRIPTION
# Motivation and Context
Still getting EstabType.forCode NPE in CCSvc , but via the modifyCase path. 

# What has changed
- added unit tests
- tolerate null estabType from RM, such that the modify operation can set EstabType.OTHER when null in RM.

# How to test?
- unit tests
- manually, need to find an RM case with estabType of null, and try the modify endpoint with EstabType OTHER. Should work (previously would fail with NPE)
- cucumber tests 

# Links
https://collaborate2.ons.gov.uk/jira/browse/CR-1841
